### PR TITLE
Parse hex integers

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -18,6 +18,7 @@
             "elm-community/graph": "6.0.0",
             "elm-community/maybe-extra": "5.0.0",
             "elm-community/result-extra": "2.2.1",
+            "rtfeldman/elm-hex": "1.0.0",
             "turboMaCk/any-dict": "1.0.1",
             "turboMaCk/any-set": "1.0.0"
         },
@@ -38,7 +39,6 @@
             "elm/virtual-dom": "1.0.2",
             "elm-community/json-extra": "4.0.0",
             "elm-community/list-extra": "8.2.0",
-            "rtfeldman/elm-hex": "1.0.0",
             "rtfeldman/elm-iso8601-date-strings": "1.1.2",
             "stil4m/structured-writer": "1.0.2"
         }

--- a/src/compiler/Error.elm
+++ b/src/compiler/Error.elm
@@ -48,6 +48,7 @@ type ParseError
 type ParseContext
     = InLiteral
     | InLiteralInt
+    | InHexInt
     | InExpr
     | InIf
     | InLet
@@ -99,7 +100,9 @@ type ParseProblem
     | ExpectingAtLeastOne
     | ExpectingNewline
     | ExpectingUnit
+    | ExpectingHexPrefix
     | InvalidInt
+    | InvalidHexInt
     | CompilerBug String
 
 

--- a/src/compiler/Stage/Parse/Parser.elm
+++ b/src/compiler/Stage/Parse/Parser.elm
@@ -405,7 +405,10 @@ literalInt =
                 |= P.getChompedString (P.chompWhile Char.isHexDigit)
                 |> P.andThen
                     (\hexString ->
-                        Hex.fromString hexString
+                        hexString
+                            -- TODO this String.toLower shouldn't be needed - see https://github.com/rtfeldman/elm-hex/pull/1
+                            |> String.toLower
+                            |> Hex.fromString
                             |> Result.map P.succeed
                             |> Result.withDefault (P.problem InvalidHexInt)
                     )

--- a/src/compiler/Stage/Parse/Parser.elm
+++ b/src/compiler/Stage/Parse/Parser.elm
@@ -32,6 +32,7 @@ import Error
         , ParseError(..)
         , ParseProblem(..)
         )
+import Hex
 import Parser.Advanced as P exposing ((|.), (|=), Parser)
 import Pratt.Advanced as PP
 import Set exposing (Set)
@@ -386,8 +387,6 @@ literal =
         |> P.inContext InLiteral
 
 
-{-| TODO deal with hex values. Use P.number and solve this+floats in one go?
--}
 literalInt : Parser_ Literal
 literalInt =
     let
@@ -399,13 +398,29 @@ literalInt =
             -}
             P.backtrackable <|
                 P.int ExpectingInt InvalidInt
+
+        hexInt =
+            P.succeed identity
+                |. P.symbol (P.Token "0x" ExpectingHexPrefix)
+                |= P.getChompedString (P.chompWhile Char.isHexDigit)
+                |> P.andThen
+                    (\hexString ->
+                        Hex.fromString hexString
+                            |> Result.map P.succeed
+                            |> Result.withDefault (P.problem InvalidHexInt)
+                    )
+                |> P.inContext InHexInt
     in
     P.succeed Int
         |= P.oneOf
             [ P.succeed negate
                 |. P.symbol (P.Token "-" ExpectingMinusSign)
-                |= int
+                |= P.oneOf
+                    [ int
+                    , hexInt
+                    ]
             , int
+            , hexInt
             ]
         |> P.inContext InLiteralInt
 
@@ -599,8 +614,9 @@ promoteArguments arguments expr_ =
 unit : ExprConfig -> Parser_ Frontend.Expr
 unit _ =
     P.succeed Frontend.Unit
-    |. P.keyword (P.Token "()" ExpectingUnit)
-    |> P.inContext InUnit
+        |. P.keyword (P.Token "()" ExpectingUnit)
+        |> P.inContext InUnit
+
 
 
 -- Helpers

--- a/tests/ParserTest.elm
+++ b/tests/ParserTest.elm
@@ -524,6 +524,10 @@ expr =
                   , "0x123abc"
                   , Ok (Literal (Int 1194684))
                   )
+                , ( "hexadecimal int - uppercase"
+                  , "0x789DEF"
+                  , Ok (Literal (Int 7904751))
+                  )
                 , ( "negative int"
                   , "-42"
                   , Ok (Literal (Int -42))
@@ -611,7 +615,6 @@ expr =
                   )
                 ]
               )
-
             ]
         )
 


### PR DESCRIPTION
This PR should fix failing tests for hex integers.

But, uppercase letters are failing. We're waiting for `rtfeldman/elm-hex` to either accept this PR: https://github.com/rtfeldman/elm-hex/pull/1 or reject it, in which case we'll probably just `String.toLower` before using `Hex.fromString`.