### PR TITLE
implement char escapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Oh God please yes! :heart: Feel free to look around the [<kbd>help wanted</kbd>]
 | ----------------- | -------------------- | -------------------- | ------------------ | ------------------ | -------------------- | ------------------ | ------------------ |
 | integers          | :heavy_check_mark:   | :warning: [[1]](#f1) | :heavy_check_mark: | :heavy_check_mark: | :warning: [[2]](#f2) | :heavy_check_mark: | :heavy_check_mark: |
 | floats            | :x: [[3]](#f3)       | :x: [[4]](#f4)       | :x: [[3]](#f3)     | :x: [[3]](#f3)     | :x: [[5]](#f5)       | :x: [[3]](#f3)     | :x: [[3]](#f3)     |
-| characters        | :warning: [[6]](#f6) | :warning: [[7]](#f7) | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:   | :heavy_check_mark: | :heavy_check_mark: |
-| strings           | :warning: [[8]](#f8) | :warning: [[9]](#f9) | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:   | :heavy_check_mark: | :heavy_check_mark: |
+| characters        | :heavy_check_mark:   | :heavy_check_mark:   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:   | :heavy_check_mark: | :heavy_check_mark: |
+| strings           | :warning: [[6]](#f6) | :warning: [[7]](#f7) | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:   | :heavy_check_mark: | :heavy_check_mark: |
 | booleans          | :heavy_check_mark:   | :heavy_check_mark:   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:   | :heavy_check_mark: | :heavy_check_mark: |
 | variables         | :warning:            | :heavy_check_mark:   | :heavy_check_mark: | :heavy_check_mark: | :warning:            | :heavy_check_mark: | :heavy_check_mark: |
 | lists             | :x:                  | :x:                  | :x:                | :x:                | :x:                  | :x:                | :x:                |
@@ -99,10 +99,8 @@ Oh God please yes! :heart: Feel free to look around the [<kbd>help wanted</kbd>]
 3. <span id="f3"></span> Not implemented; tracked in [#17](https://github.com/elm-in-elm/compiler/issues/17)
 4. <span id="f4"></span> Not implemented; not tracked yet
 5. <span id="f5"></span> To be optimized the same way Ints are; not tracked yet
-6. <span id="f6"></span> Comprehensive tests missing; will be fixed in [#15](https://github.com/elm-in-elm/compiler/pull/15)
-7. <span id="f7"></span> Escape sequences not implemented; not tracked yet
-8. <span id="f8"></span> Comprehensive tests missing; not tracked yet
-9. <span id="f9"></span> Multiline strings (and maybe more) missing; not tracked yet
+6. <span id="f6"></span> Comprehensive tests missing; not tracked yet
+7. <span id="f7"></span> Multiline strings (and maybe more) missing; not tracked yet
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ Runs `elm-test` on the test suite (gasp!)
         </br>
         <a href="https://github.com/Warry">Maxime Dantec</a>
       </td>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars0.githubusercontent.com/u/16829510">
+        </br>
+        <a href="https://github.com/aaronjanse">Aaron Janse</a>
+      </td>
     </tr>
   <tbody>
 </table>

--- a/src/compiler/Error.elm
+++ b/src/compiler/Error.elm
@@ -81,6 +81,11 @@ type ParseProblem
     | ExpectingHexadecimals
     | ExpectingSingleQuote
     | ExpectingChar
+    | ExpectingEscapeBackslash
+    | ExpectingEscapeCharacter
+    | ExpectingUnicodeEscapeLeftBrace
+    | ExpectingUnicodeEscapeRightBrace
+    | InvalidUnicodeCodePoint
     | ExpectingDoubleQuote
     | ExpectingPlusOperator
     | ExpectingModuleDot -- `import Foo>.<Bar`

--- a/src/compiler/Error.elm
+++ b/src/compiler/Error.elm
@@ -81,7 +81,7 @@ type ParseProblem
     | ExpectingSingleQuote
     | ExpectingChar
     | ExpectingEscapeBackslash
-    | ExpectingEscapeCharacter
+    | ExpectingEscapeCharacter Char
     | ExpectingUnicodeEscapeLeftBrace
     | ExpectingUnicodeEscapeRightBrace
     | InvalidUnicodeCodePoint

--- a/src/compiler/Stage/Parse/Parser.elm
+++ b/src/compiler/Stage/Parse/Parser.elm
@@ -411,7 +411,7 @@ literalInt =
 
 
 -- for literalChar and, in the future, literalString
-stringHelp = 
+character = 
     P.oneOf
     [ P.succeed identity
         |. P.token (P.Token "\\" ExpectingEscapeBackslash)
@@ -433,7 +433,7 @@ stringHelp =
                     string
                         |> String.uncons
                         |> Maybe.map (Tuple.first >> P.succeed)
-                        |> Maybe.withDefault (P.problem (CompilerBug "Multiple characters chomped in `literalChar`"))
+                        |> Maybe.withDefault (P.problem (CompilerBug "Multiple characters chomped in `character`"))
                 )
     ]
 
@@ -442,7 +442,7 @@ literalChar : Parser_ Literal
 literalChar =
     (P.succeed identity
         |. P.symbol (P.Token "'" ExpectingSingleQuote)
-        |= stringHelp
+        |= character
         |. P.symbol (P.Token "'" ExpectingSingleQuote)
     )
     |> P.map (\n -> Char n)

--- a/src/compiler/Stage/Parse/Parser.elm
+++ b/src/compiler/Stage/Parse/Parser.elm
@@ -413,7 +413,7 @@ literalInt =
 -- for literalChar and, in the future, literalString
 stringHelp = 
     P.oneOf
-    [ P.succeed (identity)
+    [ P.succeed identity
         |. P.token (P.Token "\\" ExpectingEscapeBackslash)
         |= P.oneOf
             [ P.map (\_ -> '\"') (P.token (P.Token "\"" ExpectingEscapeCharacter))

--- a/src/compiler/Stage/Parse/Parser.elm
+++ b/src/compiler/Stage/Parse/Parser.elm
@@ -445,7 +445,7 @@ literalChar =
         |= character
         |. P.symbol (P.Token "'" ExpectingSingleQuote)
     )
-    |> P.map (\n -> Char n)
+    |> P.map Char
 
 unicode : Parser_ Char
 unicode =

--- a/src/compiler/Stage/Parse/Parser.elm
+++ b/src/compiler/Stage/Parse/Parser.elm
@@ -437,13 +437,13 @@ character =
         [ P.succeed identity
             |. P.token (P.Token "\\" ExpectingEscapeBackslash)
             |= P.oneOf
-                [ P.map (\_ -> '"') (P.token (P.Token "\"" ExpectingEscapeCharacter))
-                , P.map (\_ -> '\'') (P.token (P.Token "'" ExpectingEscapeCharacter))
-                , P.map (\_ -> '\n') (P.token (P.Token "n" ExpectingEscapeCharacter))
-                , P.map (\_ -> '\t') (P.token (P.Token "t" ExpectingEscapeCharacter))
-                , P.map (\_ -> '\u{000D}') (P.token (P.Token "r" ExpectingEscapeCharacter))
+                [ P.map (\_ -> '"') (P.token (P.Token "\"" (ExpectingEscapeCharacter '"'))) -- " (elm-vscode workaround)
+                , P.map (\_ -> '\'') (P.token (P.Token "'" (ExpectingEscapeCharacter '\'')))
+                , P.map (\_ -> '\n') (P.token (P.Token "n" (ExpectingEscapeCharacter 'n')))
+                , P.map (\_ -> '\t') (P.token (P.Token "t" (ExpectingEscapeCharacter 't')))
+                , P.map (\_ -> '\u{000D}') (P.token (P.Token "r" (ExpectingEscapeCharacter 'r')))
                 , P.succeed identity
-                    |. P.token (P.Token "u" ExpectingEscapeCharacter)
+                    |. P.token (P.Token "u" (ExpectingEscapeCharacter 'u'))
                     |. P.token (P.Token "{" ExpectingUnicodeEscapeLeftBrace)
                     |= unicode
                     |. P.token (P.Token "}" ExpectingUnicodeEscapeRightBrace)

--- a/tests/ParserTest.elm
+++ b/tests/ParserTest.elm
@@ -551,6 +551,36 @@ expr =
                   , "'A'"
                   , Ok (Literal (Char 'A'))
                   )
+                  -- https://github.com/elm/compiler/blob/dcbe51fa22879f83b5d94642e117440cb5249bb1/compiler/src/Parse/String.hs#L279-L285
+                , ( "escape n"
+                  , "'\\n'"
+                  , Ok (Literal (Char '\n'))
+                  )
+                , ( "escape r"
+                  , "'\\r'"
+                  , Ok (Literal (Char '\r'))
+                  )
+                , ( "escape t"
+                  , "'\\t'"
+                  , Ok (Literal (Char '\t'))
+                  )
+                , ( "double quote"
+                  , "'\\\"'"
+                  , Ok (Literal (Char '"')) -- "
+                  )                         -- ^ workaround for official elm
+                                            --   vscode syntax highlighter
+                , ( "single quote"
+                  , "'\\\''"
+                  , Ok (Literal (Char '\''))
+                  )
+                , ( "emoji"
+                  , "'😃'"
+                  , Ok (Literal (Char '😃'))
+                  )
+                , ( "escaped unicode code point"
+                  , "'\\u{1F648}'"
+                  , Ok (Literal (Char '🙈'))
+                  )
                 ]
               )
             , ( "literal string"

--- a/tests/ParserTest.elm
+++ b/tests/ParserTest.elm
@@ -555,14 +555,15 @@ expr =
                   , "'A'"
                   , Ok (Literal (Char 'A'))
                   )
-                  -- https://github.com/elm/compiler/blob/dcbe51fa22879f83b5d94642e117440cb5249bb1/compiler/src/Parse/String.hs#L279-L285
+
+                -- https://github.com/elm/compiler/blob/dcbe51fa22879f83b5d94642e117440cb5249bb1/compiler/src/Parse/String.hs#L279-L285
                 , ( "escape n"
                   , "'\\n'"
                   , Ok (Literal (Char '\n'))
                   )
                 , ( "escape r"
                   , "'\\r'"
-                  , Ok (Literal (Char '\r'))
+                  , Ok (Literal (Char '\u{000D}'))
                   )
                 , ( "escape t"
                   , "'\\t'"
@@ -570,11 +571,11 @@ expr =
                   )
                 , ( "double quote"
                   , "'\\\"'"
-                  , Ok (Literal (Char '"')) -- "
-                  )                         -- ^ workaround for official elm
-                                            --   vscode syntax highlighter
+                  , Ok (Literal (Char '"'))
+                    -- " (for vscode-elm bug)
+                  )
                 , ( "single quote"
-                  , "'\\\''"
+                  , "'\\''"
                   , Ok (Literal (Char '\''))
                   )
                 , ( "emoji"


### PR DESCRIPTION
fix #11 

This is based on the [Elm Parser example code](https://github.com/elm/parser/blob/master/examples/DoubleQuoteString.elm) (which has [a bug][bug] btw). I wish I found it earlier.

I wrote the PR such that we can later reuse the escape-handling code for `literalString`.

[bug]: https://github.com/elm/parser/pull/35