### PR TITLE
Type to string

### DIFF
--- a/src/compiler/AST/Common/Type.elm
+++ b/src/compiler/AST/Common/Type.elm
@@ -31,10 +31,11 @@ getVarId type_ =
         _ ->
             Nothing
 
+
 toString : Type -> String
 toString type_ =
     getTypeVariablesIndex type_
-    |> toStringHelp type_
+        |> toStringHelp type_
 
 
 toStringHelp : Type -> Dict Int String -> String
@@ -42,7 +43,7 @@ toStringHelp type_ dict =
     case type_ of
         Var int ->
             Dict.get int dict
-            |> Maybe.withDefault ("t" ++ String.fromInt int)
+                |> Maybe.withDefault ("t" ++ String.fromInt int)
 
         Function t1 t2 ->
             wrapParens t1 dict ++ " -> " ++ toStringHelp t2 dict
@@ -71,51 +72,57 @@ toStringHelp type_ dict =
 
 getTypeVariablesIndex : Type -> Dict Int String
 getTypeVariablesIndex type_ =
-    getTypeVariablesIndexHelp type_ (typeVariablesLetters, Dict.empty)
-    |> Tuple.second
+    ( typeVariablesLetters, Dict.empty )
+        |> getTypeVariablesIndexHelp type_
+        |> Tuple.second
 
 
-getTypeVariablesIndexHelp : Type -> (List String, Dict Int String) -> (List String, Dict Int String)
-getTypeVariablesIndexHelp type_ (freeLetters, dict) =
+getTypeVariablesIndexHelp : Type -> ( List String, Dict Int String ) -> ( List String, Dict Int String )
+getTypeVariablesIndexHelp type_ ( freeLetters, dict ) =
     case type_ of
         Var int ->
             case freeLetters of
                 [] ->
-                    ([], dict)
+                    ( [], dict )
 
                 hd :: xs ->
                     if Dict.member int dict then
-                        (freeLetters, dict)
+                        ( freeLetters, dict )
+
                     else
-                        (xs, Dict.insert int hd dict)
+                        ( xs, Dict.insert int hd dict )
 
         Function t1 t2 ->
-            getTypeVariablesIndexHelp t1 (freeLetters, dict)
-            |> getTypeVariablesIndexHelp t2
+            ( freeLetters, dict )
+                |> getTypeVariablesIndexHelp t1
+                |> getTypeVariablesIndexHelp t2
 
         List param ->
-            getTypeVariablesIndexHelp param (freeLetters, dict)
+            getTypeVariablesIndexHelp param ( freeLetters, dict )
 
         Int ->
-            (freeLetters, dict)
+            ( freeLetters, dict )
 
         Float ->
-            (freeLetters, dict)
+            ( freeLetters, dict )
 
         Char ->
-            (freeLetters, dict)
+            ( freeLetters, dict )
 
         String ->
-            (freeLetters, dict)
+            ( freeLetters, dict )
 
         Bool ->
-            (freeLetters, dict)
+            ( freeLetters, dict )
 
         Unit ->
-            (freeLetters, dict)
+            ( freeLetters, dict )
+
 
 
 -- Stops at letter `s`, so that outbound variables display `tN`
+
+
 typeVariablesLetters =
     [ "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s" ]
 

--- a/src/compiler/AST/Common/Type.elm
+++ b/src/compiler/AST/Common/Type.elm
@@ -45,7 +45,7 @@ toStringHelp type_ dict =
             |> Maybe.withDefault ("t" ++ String.fromInt int)
 
         Function t1 t2 ->
-            toString t1 ++ " -> " ++ toString t2
+            wrapParens t1 dict ++ " -> " ++ toStringHelp t2 dict
 
         Int ->
             "Int"
@@ -63,7 +63,7 @@ toStringHelp type_ dict =
             "Bool"
 
         List param ->
-            "List " ++ toString param
+            "List " ++ wrapParens param dict
 
         Unit ->
             "()"
@@ -76,15 +76,18 @@ getTypeVariablesIndex type_ =
 
 
 getTypeVariablesIndexHelp : Type -> (List String, Dict Int String) -> (List String, Dict Int String)
-getTypeVariablesIndexHelp currentType (freeLetters, dict) =
-    case currentType of
+getTypeVariablesIndexHelp type_ (freeLetters, dict) =
+    case type_ of
         Var int ->
             case freeLetters of
                 [] ->
                     ([], dict)
 
                 hd :: xs ->
-                    (xs, Dict.insert int hd dict)
+                    if Dict.member int dict then
+                        (freeLetters, dict)
+                    else
+                        (xs, Dict.insert int hd dict)
 
         Function t1 t2 ->
             getTypeVariablesIndexHelp t1 (freeLetters, dict)
@@ -115,3 +118,16 @@ getTypeVariablesIndexHelp currentType (freeLetters, dict) =
 -- Stops at letter `s`, so that outbound variables display `tN`
 typeVariablesLetters =
     [ "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s" ]
+
+
+wrapParens : Type -> Dict Int String -> String
+wrapParens type_ dict =
+    case type_ of
+        Function t1 t2 ->
+            "(" ++ toStringHelp type_ dict ++ ")"
+
+        List param ->
+            "(" ++ toStringHelp type_ dict ++ ")"
+
+        _ ->
+            toStringHelp type_ dict

--- a/src/compiler/AST/Common/Type.elm
+++ b/src/compiler/AST/Common/Type.elm
@@ -1,9 +1,9 @@
 module AST.Common.Type exposing
     ( State
     , Type(..)
-    , dump
-    , empty
+    , emptyState
     , getVarId
+    , niceVarName
     , toString
     )
 
@@ -25,13 +25,6 @@ type Type
     | Unit
 
 
-type State
-    = State
-        { freeLetters : List String
-        , mapping : Dict Int String
-        }
-
-
 getVarId : Type -> Maybe Int
 getVarId type_ =
     case type_ of
@@ -42,35 +35,55 @@ getVarId type_ =
             Nothing
 
 
-empty : State
-empty =
-    State
-        { freeLetters = varsLetters
-        , mapping = Dict.empty
+
+--------------
+-- toString --
+--------------
+
+
+type State
+    = State
+        { mapping : Dict Int String
+        , counter : Int
         }
 
 
-toString : Type -> State -> ( String, State )
-toString type_ state =
+emptyState : State
+emptyState =
+    State
+        { mapping = Dict.empty
+        , counter = 0
+        }
+
+
+toString : State -> Type -> ( String, State )
+toString state type_ =
     case type_ of
         Var int ->
-            getVariable int state
+            getName state int
 
         Function t1 t2 ->
             let
-                ( type1, state1 ) =
-                    wrapParens t1 state
+                ( t1String, state1 ) =
+                    toString state t1
+                        |> maybeWrapParens t1
 
-                ( type2, state2 ) =
-                    toString t2 state1
+                ( t2String, state2 ) =
+                    toString state1 t2
             in
-            ( type1 ++ " -> " ++ type2
+            ( t1String ++ " -> " ++ t2String
             , state2
             )
 
         List param ->
-            wrapParens param state
-                |> Tuple.mapFirst ((++) "List ")
+            let
+                ( paramString, state1 ) =
+                    toString state param
+                        |> maybeWrapParens param
+            in
+            ( "List " ++ paramString
+            , state1
+            )
 
         Int ->
             ( "Int", state )
@@ -91,54 +104,107 @@ toString type_ state =
             ( "Unit", state )
 
 
-dump : Type -> String
-dump type_ =
-    toString type_ empty
-        |> Tuple.first
-
-
-getVariable : Int -> State -> ( String, State )
-getVariable int ((State { freeLetters, mapping }) as state) =
-    case Dict.get int mapping of
-        Just letter ->
-            ( letter
-            , state
-            )
+getName : State -> Int -> ( String, State )
+getName ((State { counter, mapping }) as state) varId =
+    case Dict.get varId mapping of
+        Just letter_ ->
+            ( letter_, state )
 
         Nothing ->
-            case freeLetters of
-                letter :: letters ->
-                    ( letter
-                    , State
-                        { freeLetters = letters
-                        , mapping = Dict.insert int letter mapping
-                        }
-                    )
-
-                [] ->
-                    ( "t" ++ String.fromInt int
-                    , state
-                    )
-
-
-varsLetters : List String
-varsLetters =
-    -- Stops at letter `s`, so that outbound variables display `tN`
-    [ "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s" ]
-
-
-wrapParens : Type -> State -> ( String, State )
-wrapParens type_ state =
-    toString type_ state
-        |> Tuple.mapFirst
-            (\t ->
-                case type_ of
-                    Function t1 t2 ->
-                        "(" ++ t ++ ")"
-
-                    List param ->
-                        "(" ++ t ++ ")"
-
-                    _ ->
-                        t
+            let
+                name =
+                    niceVarName counter
+            in
+            ( name
+            , State
+                { counter = counter + 1
+                , mapping = Dict.insert varId name mapping
+                }
             )
+
+
+{-| We're generating the nice variable names using this sequence:
+
+    a, b, ..., z, | a1, b1, ..., z1, | a2, b2, ..., z2, | ...
+    0  1       25 | 26  27       51  | 52  53       77  |
+
+-}
+niceVarName : Int -> String
+niceVarName id =
+    if id < 26 then
+        letter id
+
+    else
+        let
+            wraparounds =
+                id // 26
+
+            remainder =
+                id |> modBy 26
+        in
+        letter remainder ++ String.fromInt wraparounds
+
+
+letter : Int -> String
+letter int =
+    (int + 97 {- `a` -})
+        |> Char.fromCode
+        |> String.fromChar
+
+
+{-|
+
+    maybeWrapParens (List Int) ( "List Int", state )
+
+    -->
+    ( "(List Int)", state )
+
+    maybeWrapParens Int ( "Int", state )
+
+    -->
+    ( "Int", state )
+
+-}
+maybeWrapParens : Type -> ( String, a ) -> ( String, a )
+maybeWrapParens type_ ( string, state ) =
+    let
+        wrapParens : String -> String
+        wrapParens x =
+            "(" ++ x ++ ")"
+    in
+    if shouldWrapParens type_ then
+        ( wrapParens string, state )
+
+    else
+        ( string, state )
+
+
+shouldWrapParens : Type -> Bool
+shouldWrapParens type_ =
+    case type_ of
+        Var _ ->
+            False
+
+        Function t1 t2 ->
+            True
+
+        Int ->
+            False
+
+        Float ->
+            False
+
+        Char ->
+            False
+
+        String ->
+            False
+
+        Bool ->
+            False
+
+        List param ->
+            True
+
+        Unit ->
+            False

--- a/src/compiler/Error.elm
+++ b/src/compiler/Error.elm
@@ -185,11 +185,11 @@ toString error =
                 TypeMismatch t1 t2 ->
                     let
                         -- Share index between types
-                        ( type1, index1 ) =
-                            Type.toStringWithVars t1 Type.emptyVars
+                        ( type1, state1 ) =
+                            Type.toString t1 Type.empty
 
                         ( type2, _ ) =
-                            Type.toStringWithVars t2 index1
+                            Type.toString t2 state1
                     in
                     "The types `"
                         ++ type1
@@ -198,10 +198,17 @@ toString error =
                         ++ "` don't match."
 
                 OccursCheckFailed varId type_ ->
+                    let
+                        ( type1, state1 ) =
+                            Type.toString (Type.Var varId) Type.empty
+
+                        ( type2, _ ) =
+                            Type.toString type_ state1
+                    in
                     "An \"occurs check\" failed while typechecking: "
-                        ++ Type.toString (Type.Var varId)
+                        ++ type1
                         ++ " occurs in "
-                        ++ Type.toString type_
+                        ++ type2
 
         PrepareForBackendError prepareForBackendError ->
             case prepareForBackendError of

--- a/src/compiler/Error.elm
+++ b/src/compiler/Error.elm
@@ -183,11 +183,19 @@ toString error =
         TypeError typeError ->
             case typeError of
                 TypeMismatch t1 t2 ->
-                    "The types "
-                        ++ Type.toString t1
-                        ++ " and "
-                        ++ Type.toString t2
-                        ++ " don't match."
+                    let
+                        -- Share index between types
+                        ( type1, index1 ) =
+                            Type.toStringWithVars t1 Type.emptyVars
+
+                        ( type2, _ ) =
+                            Type.toStringWithVars t2 index1
+                    in
+                    "The types `"
+                        ++ type1
+                        ++ "` and `"
+                        ++ type2
+                        ++ "` don't match."
 
                 OccursCheckFailed varId type_ ->
                     "An \"occurs check\" failed while typechecking: "

--- a/src/compiler/Error.elm
+++ b/src/compiler/Error.elm
@@ -186,10 +186,10 @@ toString error =
                     let
                         -- Share index between types
                         ( type1, state1 ) =
-                            Type.toString t1 Type.empty
+                            Type.toString Type.emptyState t1
 
                         ( type2, _ ) =
-                            Type.toString t2 state1
+                            Type.toString state1 t2
                     in
                     "The types `"
                         ++ type1
@@ -200,10 +200,10 @@ toString error =
                 OccursCheckFailed varId type_ ->
                     let
                         ( type1, state1 ) =
-                            Type.toString (Type.Var varId) Type.empty
+                            Type.toString Type.emptyState (Type.Var varId)
 
                         ( type2, _ ) =
-                            Type.toString type_ state1
+                            Type.toString state1 type_
                     in
                     "An \"occurs check\" failed while typechecking: "
                         ++ type1

--- a/src/compiler/Stage/PrepareForBackend.elm
+++ b/src/compiler/Stage/PrepareForBackend.elm
@@ -186,7 +186,7 @@ findDependencies modules ( expr, _ ) =
             bindingsDependencies
                 ++ findDependencies_ body
 
-        List item ->
+        List items ->
             List.concatMap findDependencies_ items
 
         Unit ->

--- a/tests/InferTypesTest.elm
+++ b/tests/InferTypesTest.elm
@@ -1,10 +1,11 @@
-module InferTypesTest exposing (typeInference)
+module InferTypesTest exposing (typeInference, typeToString)
 
 import AST.Canonical as Canonical
 import AST.Common.Literal exposing (Literal(..))
 import AST.Common.Type as Type exposing (Type)
 import AST.Typed as Typed
 import Common
+import Common.Types as Types
 import Dict.Any
 import Error exposing (TypeError)
 import Expect exposing (Expectation)
@@ -47,6 +48,55 @@ typeInference =
                 , ( "more items with different types"
                   , Canonical.List [ Canonical.Literal (Bool True), Canonical.Literal (String "two"), Canonical.Literal (Int 3) ]
                   , Err (Error.TypeMismatch Type.Bool Type.String)
+                  )
+                ]
+              )
+            ]
+        )
+
+
+typeToString : Test
+typeToString =
+    let
+        runSection ( description, tests ) =
+            describe description
+                (List.map runTest tests)
+
+        runTest ( description, input, output ) =
+            test description <|
+                \() ->
+                    Type.toString input
+                        |> Expect.equal output
+    in
+    describe "Type.toString"
+        (List.map runSection
+            [ ( "list"
+              , [ ( "empty list"
+                  , Type.List (Type.Var 0)
+                  , "List a"
+                  )
+                , ( "one item in list"
+                  , Type.List Type.Bool
+                  , "List Bool"
+                  )
+                ]
+              )
+            , ( "lambda"
+              , [ ( "function with one param"
+                  , Type.Function (Type.Var 0) Type.Int
+                  , "a -> Int"
+                  )
+                , ( "function with two params"
+                  , Type.Function (Type.Var 0) (Type.Function (Type.Var 1) (Type.Var 1))
+                  , "a -> b -> b"
+                  )
+                , ( "function as params"
+                  , Type.Function (Type.Function (Type.Var 1) (Type.Var 1)) (Type.Var 0)
+                  , "(b -> b) -> a"
+                  )
+                , ( "list of functions"
+                  , Type.List (Type.Function (Type.Var 0) (Type.Var 0))
+                  , "List (a -> a)"
                   )
                 ]
               )

--- a/tests/InferTypesTest.elm
+++ b/tests/InferTypesTest.elm
@@ -58,10 +58,16 @@ typeInference =
 typeToString : Test
 typeToString =
     let
+        toStringOnce : Type -> String
+        toStringOnce type_ =
+            type_
+                |> Type.toString Type.emptyState
+                |> Tuple.first
+
         runTest ( description, input, output ) =
             test description <|
                 \() ->
-                    Type.dump input
+                    toStringOnce input
                         |> Expect.equal output
 
         runEqual ( description, input, output ) =
@@ -112,8 +118,8 @@ typeToString =
         , describe "edges"
             [ runEqual
                 ( "Var number doesn't count"
-                , Type.dump <| Type.List (Type.Var 0)
-                , Type.dump <| Type.List (Type.Var 1)
+                , toStringOnce <| Type.List (Type.Var 0)
+                , toStringOnce <| Type.List (Type.Var 1)
                 )
             , runEqual
                 ( "TypeMismatch types share vars index"
@@ -128,3 +134,35 @@ typeToString =
                 )
             ]
         ]
+
+
+niceVarName : Test
+niceVarName =
+    let
+        runTest ( input, output ) =
+            test output <|
+                \() ->
+                    Type.niceVarName input
+                        |> Expect.equal output
+    in
+    describe "Type.niceVarName" <|
+        List.map runTest
+            [ ( 0, "a" )
+            , ( 1, "b" )
+            , ( 2, "c" )
+            , ( 25, "z" )
+
+            --
+            , ( 26, "a1" )
+            , ( 49, "x1" )
+            , ( 50, "y1" )
+            , ( 51, "z1" )
+
+            --
+            , ( 52, "a2" )
+            , ( 77, "z2" )
+
+            --
+            , ( 259, "z9" )
+            , ( 260, "a10" )
+            ]

--- a/tests/InferTypesTest.elm
+++ b/tests/InferTypesTest.elm
@@ -67,7 +67,7 @@ typeToString =
         runEqual ( description, input, output ) =
             test description <|
                 \() ->
-                    Expect.equal (Type.toString input) (Type.toString output)
+                    Expect.equal input output
     in
     describe "Type.toString"
         [ describe "list"
@@ -75,11 +75,6 @@ typeToString =
                 ( "empty list"
                 , Type.List (Type.Var 0)
                 , "List a"
-                )
-            , runEqual
-                ( "Var number doesn't count"
-                , Type.List (Type.Var 0)
-                , Type.List (Type.Var 1)
                 )
             , runTest
                 ( "one item in list"
@@ -112,6 +107,24 @@ typeToString =
                 ( "list of functions"
                 , Type.List (Type.Function (Type.Var 0) (Type.Var 0))
                 , "List (a -> a)"
+                )
+            ]
+        , describe "edges"
+            [ runEqual
+                ( "Var number doesn't count"
+                , Type.toString <| Type.List (Type.Var 0)
+                , Type.toString <| Type.List (Type.Var 1)
+                )
+            , runEqual
+                ( "TypeMismatch types share vars index"
+                , Error.toString
+                    (Error.TypeError
+                        (Error.TypeMismatch
+                            (Type.Function (Type.List (Type.Var 0)) (Type.Var 1))
+                            (Type.Function (Type.List (Type.Var 1)) (Type.Var 0))
+                        )
+                    )
+                , "The types `(List a) -> b` and `(List b) -> a` don't match."
                 )
             ]
         ]

--- a/tests/InferTypesTest.elm
+++ b/tests/InferTypesTest.elm
@@ -61,7 +61,7 @@ typeToString =
         runTest ( description, input, output ) =
             test description <|
                 \() ->
-                    Type.toString input
+                    Type.dump input
                         |> Expect.equal output
 
         runEqual ( description, input, output ) =
@@ -112,8 +112,8 @@ typeToString =
         , describe "edges"
             [ runEqual
                 ( "Var number doesn't count"
-                , Type.toString <| Type.List (Type.Var 0)
-                , Type.toString <| Type.List (Type.Var 1)
+                , Type.dump <| Type.List (Type.Var 0)
+                , Type.dump <| Type.List (Type.Var 1)
                 )
             , runEqual
                 ( "TypeMismatch types share vars index"

--- a/tests/InferTypesTest.elm
+++ b/tests/InferTypesTest.elm
@@ -58,51 +58,60 @@ typeInference =
 typeToString : Test
 typeToString =
     let
-        runSection ( description, tests ) =
-            describe description
-                (List.map runTest tests)
-
         runTest ( description, input, output ) =
             test description <|
                 \() ->
                     Type.toString input
                         |> Expect.equal output
+
+        runEqual ( description, input, output ) =
+            test description <|
+                \() ->
+                    Expect.equal (Type.toString input) (Type.toString output)
     in
     describe "Type.toString"
-        (List.map runSection
-            [ ( "list"
-              , [ ( "empty list"
-                  , Type.List (Type.Var 0)
-                  , "List a"
-                  )
-                , ( "one item in list"
-                  , Type.List Type.Bool
-                  , "List Bool"
-                  )
-                , ( "list of list of String"
-                  , Type.List (Type.List Type.String)
-                  , "List (List String)"
-                  )
-                ]
-              )
-            , ( "lambda"
-              , [ ( "function with one param"
-                  , Type.Function (Type.Var 99) Type.Int
-                  , "a -> Int"
-                  )
-                , ( "function with two params"
-                  , Type.Function (Type.Var 0) (Type.Function (Type.Var 1) (Type.Var 1))
-                  , "a -> b -> b"
-                  )
-                , ( "function as param"
-                  , Type.Function (Type.Function (Type.Var 9) (Type.Var 9)) (Type.Var 0)
-                  , "(a -> a) -> b"
-                  )
-                , ( "list of functions"
-                  , Type.List (Type.Function (Type.Var 0) (Type.Var 0))
-                  , "List (a -> a)"
-                  )
-                ]
-              )
+        [ describe "list"
+            [ runTest
+                ( "empty list"
+                , Type.List (Type.Var 0)
+                , "List a"
+                )
+            , runEqual
+                ( "Var number doesn't count"
+                , Type.List (Type.Var 0)
+                , Type.List (Type.Var 1)
+                )
+            , runTest
+                ( "one item in list"
+                , Type.List Type.Bool
+                , "List Bool"
+                )
+            , runTest
+                ( "list of list of String"
+                , Type.List (Type.List Type.String)
+                , "List (List String)"
+                )
             ]
-        )
+        , describe "lambda"
+            [ runTest
+                ( "function with one param"
+                , Type.Function (Type.Var 99) Type.Int
+                , "a -> Int"
+                )
+            , runTest
+                ( "function with two params"
+                , Type.Function (Type.Var 0) (Type.Function (Type.Var 1) (Type.Var 1))
+                , "a -> b -> b"
+                )
+            , runTest
+                ( "function as param"
+                , Type.Function (Type.Function (Type.Var 9) (Type.Var 9)) (Type.Var 0)
+                , "(a -> a) -> b"
+                )
+            , runTest
+                ( "list of functions"
+                , Type.List (Type.Function (Type.Var 0) (Type.Var 0))
+                , "List (a -> a)"
+                )
+            ]
+        ]

--- a/tests/InferTypesTest.elm
+++ b/tests/InferTypesTest.elm
@@ -79,20 +79,24 @@ typeToString =
                   , Type.List Type.Bool
                   , "List Bool"
                   )
+                , ( "list of list of String"
+                  , Type.List (Type.List Type.String)
+                  , "List (List String)"
+                  )
                 ]
               )
             , ( "lambda"
               , [ ( "function with one param"
-                  , Type.Function (Type.Var 0) Type.Int
+                  , Type.Function (Type.Var 99) Type.Int
                   , "a -> Int"
                   )
                 , ( "function with two params"
                   , Type.Function (Type.Var 0) (Type.Function (Type.Var 1) (Type.Var 1))
                   , "a -> b -> b"
                   )
-                , ( "function as params"
-                  , Type.Function (Type.Function (Type.Var 1) (Type.Var 1)) (Type.Var 0)
-                  , "(b -> b) -> a"
+                , ( "function as param"
+                  , Type.Function (Type.Function (Type.Var 9) (Type.Var 9)) (Type.Var 0)
+                  , "(a -> a) -> b"
                   )
                 , ( "list of functions"
                   , Type.List (Type.Function (Type.Var 0) (Type.Var 0))


### PR DESCRIPTION
fixes #41
also add parens when needed:
`List ((a -> b) -> b)`