### PR TITLE
Add support for tuples and 3-tuples

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ Oh God please yes! :heart: Feel free to look around the [<kbd>help wanted</kbd>]
 7. <span id="f7"></span> Multiline strings (and maybe more) missing; tracked in [#33](https://github.com/elm-in-elm/compiler/issues/33)
 8. <span id="f8"></span> Not implemented; partially tracked in [#29](https://github.com/elm-in-elm/compiler/issues/29)
 9. <span id="f9"></span> ... this space left intentionally blank :smile: ...
-10. <span id="f10"></span> Not implemented; tracked in [#34](https://github.com/elm-in-elm/compiler/issues/34)
-11. <span id="f11"></span> Not implemented; tracked in [#35](https://github.com/elm-in-elm/compiler/issues/35)
+10. <span id="f11"></span> Not implemented; tracked in [#35](https://github.com/elm-in-elm/compiler/issues/35)
 
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Oh God please yes! :heart: Feel free to look around the [<kbd>help wanted</kbd>]
 | record accessors  | :x:                  | :x:                  | :x:                  | :x:                  | :x:                | :x:                | :x:                  | :x:                  |
 | record updates    | :x:                  | :x:                  | :x:                  | :x:                  | :x:                | :x:                | :x:                  | :x:                  |
 | unit type         | :heavy_check_mark:   | :heavy_check_mark:   | :heavy_check_mark:   | :heavy_check_mark:   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:   | :heavy_check_mark:   |
-| tuples, 3-tuples  | :x: [[10]](#f10)     | :heavy_check_mark:   | :x: [[10]](#f10)     | :x: [[11]](#f11)     | :heavy_check_mark: | :x: [[10]](#f10)   | :heavy_check_mark:   | :x: [[10]](#f10)     |
+| tuples, 3-tuples  | :heavy_check_mark:    | :heavy_check_mark:   | heavy_check_mark    | :x: [[11]](#f11)     | :heavy_check_mark: | heavy_check_mark   | :heavy_check_mark:   | :heavy_check_mark:  |
 | type annotations  | :x:                  | :x:                  | :x:                  | :x:                  | :x:                | :x:                | :x:                  | :x:                  |
 | type aliases      | :x:                  | :x:                  | :x:                  | :x:                  | :x:                | :x:                | :x:                  | :x:                  |
 | custom types      | :x:                  | :x:                  | :x:                  | :x:                  | :x:                | :x:                | :x:                  | :x:                  |

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Oh God please yes! :heart: Feel free to look around the [<kbd>help wanted</kbd>]
 | record accessors  | :x:                  | :x:                  | :x:                  | :x:                  | :x:                | :x:                | :x:                  | :x:                  |
 | record updates    | :x:                  | :x:                  | :x:                  | :x:                  | :x:                | :x:                | :x:                  | :x:                  |
 | unit type         | :heavy_check_mark:   | :heavy_check_mark:   | :heavy_check_mark:   | :heavy_check_mark:   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:   | :heavy_check_mark:   |
-| tuples, 3-tuples  | :heavy_check_mark:    | :heavy_check_mark:   | heavy_check_mark    | :x: [[11]](#f11)     | :heavy_check_mark: | heavy_check_mark   | :heavy_check_mark:   | :heavy_check_mark:  |
+| tuples, 3-tuples  | :heavy_check_mark:    | :heavy_check_mark:   | heavy_check_mark    | :x: [[10]](#f10)     | :heavy_check_mark: | heavy_check_mark   | :heavy_check_mark:   | :heavy_check_mark:  |
 | type annotations  | :x:                  | :x:                  | :x:                  | :x:                  | :x:                | :x:                | :x:                  | :x:                  |
 | type aliases      | :x:                  | :x:                  | :x:                  | :x:                  | :x:                | :x:                | :x:                  | :x:                  |
 | custom types      | :x:                  | :x:                  | :x:                  | :x:                  | :x:                | :x:                | :x:                  | :x:                  |
@@ -103,7 +103,7 @@ Oh God please yes! :heart: Feel free to look around the [<kbd>help wanted</kbd>]
 7. <span id="f7"></span> Multiline strings (and maybe more) missing; tracked in [#33](https://github.com/elm-in-elm/compiler/issues/33)
 8. <span id="f8"></span> Not implemented; partially tracked in [#29](https://github.com/elm-in-elm/compiler/issues/29)
 9. <span id="f9"></span> ... this space left intentionally blank :smile: ...
-10. <span id="f11"></span> Not implemented; tracked in [#35](https://github.com/elm-in-elm/compiler/issues/35)
+10. <span id="f10"></span> Not implemented; tracked in [#35](https://github.com/elm-in-elm/compiler/issues/35)
 
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -258,6 +258,12 @@ Make sure to format code before submitting a pull request!
     <tr>
       <td align="center">
         <img width="150" height="150"
+        src="https://avatars1.githubusercontent.com/u/3983879">
+        </br>
+        Eduard Kyvenko
+      </td>
+      <td align="center">
+        <img width="150" height="150"
         src="https://raw.github.com/elm-in-elm/compiler/master/assets/user-placeholder.png">
         </br>
         You?

--- a/src/compiler/AST/Canonical.elm
+++ b/src/compiler/AST/Canonical.elm
@@ -37,6 +37,8 @@ type Expr
     | Let { bindings : AnyDict String VarName (Binding Expr), body : Expr }
     | List (List Expr)
     | Unit
+    | Tuple Expr Expr
+    | Tuple3 Expr Expr Expr
 
 
 var : ModuleName -> VarName -> Expr

--- a/src/compiler/AST/Common/Type.elm
+++ b/src/compiler/AST/Common/Type.elm
@@ -23,6 +23,8 @@ type Type
     | Bool
     | List Type
     | Unit
+    | Tuple Type Type
+    | Tuple3 Type Type Type
 
 
 getVarId : Type -> Maybe Int
@@ -102,6 +104,29 @@ toString state type_ =
 
         Unit ->
             ( "Unit", state )
+
+        Tuple t1 t2 ->
+            let
+                ( t1String, state1 ) =
+                    toString state t1
+
+                ( t2String, state2 ) =
+                    toString state1 t2
+            in
+            ( "(" ++ t1String ++ "," ++ t2String ++ ")", state2 )
+
+        Tuple3 t1 t2 t3 ->
+            let
+                ( t1String, state1 ) =
+                    toString state t1
+
+                ( t2String, state2 ) =
+                    toString state1 t2
+
+                ( t3String, state3 ) =
+                    toString state2 t3
+            in
+            ( "(" ++ t1String ++ "," ++ t2String ++ ", " ++ t3String ++ ")", state2 )
 
 
 getName : State -> Int -> ( String, State )

--- a/src/compiler/AST/Common/Type.elm
+++ b/src/compiler/AST/Common/Type.elm
@@ -113,7 +113,7 @@ toString state type_ =
                 ( t2String, state2 ) =
                     toString state1 t2
             in
-            ( "(" ++ t1String ++ "," ++ t2String ++ ")", state2 )
+            ( "( " ++ t1String ++ ", " ++ t2String ++ " )", state2 )
 
         Tuple3 t1 t2 t3 ->
             let
@@ -126,7 +126,7 @@ toString state type_ =
                 ( t3String, state3 ) =
                     toString state2 t3
             in
-            ( "(" ++ t1String ++ "," ++ t2String ++ "," ++ t3String ++ ")", state2 )
+            ( "( " ++ t1String ++ ", " ++ t2String ++ ", " ++ t3String ++ " )", state3 )
 
 
 getName : State -> Int -> ( String, State )

--- a/src/compiler/AST/Common/Type.elm
+++ b/src/compiler/AST/Common/Type.elm
@@ -126,7 +126,7 @@ toString state type_ =
                 ( t3String, state3 ) =
                     toString state2 t3
             in
-            ( "(" ++ t1String ++ "," ++ t2String ++ ", " ++ t3String ++ ")", state2 )
+            ( "(" ++ t1String ++ "," ++ t2String ++ "," ++ t3String ++ ")", state2 )
 
 
 getName : State -> Int -> ( String, State )
@@ -232,4 +232,10 @@ shouldWrapParens type_ =
             True
 
         Unit ->
+            False
+
+        Tuple _ _ ->
+            False
+
+        Tuple3 _ _ _ ->
             False

--- a/src/compiler/AST/Frontend.elm
+++ b/src/compiler/AST/Frontend.elm
@@ -114,7 +114,7 @@ recurse f expr =
 
         Unit ->
             expr
-        
+
         Tuple e1 e2 ->
             Tuple (f e1) (f e2)
 

--- a/src/compiler/AST/Frontend.elm
+++ b/src/compiler/AST/Frontend.elm
@@ -33,6 +33,8 @@ type Expr
     | Let { bindings : List (Binding Expr), body : Expr }
     | List (List Expr)
     | Unit
+    | Tuple Expr Expr
+    | Tuple3 Expr Expr Expr
 
 
 var : Maybe ModuleName -> VarName -> Expr
@@ -112,6 +114,12 @@ recurse f expr =
 
         Unit ->
             expr
+        
+        Tuple e1 e2 ->
+            Tuple (f e1) (f e2)
+
+        Tuple3 e1 e2 e3 ->
+            Tuple3 (f e1) (f e2) (f e3)
 
 
 transform : (Expr -> Expr) -> Expr -> Expr

--- a/src/compiler/AST/Typed.elm
+++ b/src/compiler/AST/Typed.elm
@@ -190,3 +190,9 @@ recursiveChildren fn ( expr, _ ) =
 
         List items ->
             List.concatMap fn items
+
+        Tuple e1 e2 ->
+            fn e1 ++ fn e2
+
+        Tuple3 e1 e2 e3 ->
+            fn e1 ++ fn e2 ++ fn e3

--- a/src/compiler/AST/Typed.elm
+++ b/src/compiler/AST/Typed.elm
@@ -53,6 +53,8 @@ type Expr_
     | Let { bindings : AnyDict String VarName (Binding Expr), body : Expr }
     | List (List Expr)
     | Unit
+    | Tuple Expr Expr
+    | Tuple3 Expr Expr Expr
 
 
 lambda : VarName -> Expr -> Expr_
@@ -115,6 +117,12 @@ recurse f ( expr, type_ ) =
 
         Unit ->
             expr
+
+        Tuple e1 e2 ->
+            Tuple (f e1) (f e2)
+
+        Tuple3 e1 e2 e3 ->
+            Tuple3 (f e1) (f e2) (f e3)
     , type_
     )
 

--- a/src/compiler/Stage/Desugar.elm
+++ b/src/compiler/Stage/Desugar.elm
@@ -71,9 +71,10 @@ desugarExpr modules thisModule expr =
 
         Frontend.Tuple e1 e2 ->
             desugarTuple recurse e1 e2
-        
+
         Frontend.Tuple3 e1 e2 e3 ->
             desugarTuple3 recurse e1 e2 e3
+
 
 
 -- DESUGAR PASSES
@@ -165,6 +166,7 @@ desugarUnit : Result DesugarError Canonical.Expr
 desugarUnit =
     Ok Canonical.Unit
 
+
 desugarTuple : (Frontend.Expr -> Result DesugarError Canonical.Expr) -> Frontend.Expr -> Frontend.Expr -> Result DesugarError Canonical.Expr
 desugarTuple recurse e1 e2 =
     Result.map2 Canonical.Tuple
@@ -178,6 +180,7 @@ desugarTuple3 recurse e1 e2 e3 =
         (recurse e1)
         (recurse e2)
         (recurse e3)
+
 
 
 -- HELPERS

--- a/src/compiler/Stage/Desugar.elm
+++ b/src/compiler/Stage/Desugar.elm
@@ -69,6 +69,11 @@ desugarExpr modules thisModule expr =
         Frontend.Unit ->
             desugarUnit
 
+        Frontend.Tuple e1 e2 ->
+            desugarTuple recurse e1 e2
+        
+        Frontend.Tuple3 e1 e2 e3 ->
+            desugarTuple3 recurse e1 e2 e3
 
 
 -- DESUGAR PASSES
@@ -160,6 +165,19 @@ desugarUnit : Result DesugarError Canonical.Expr
 desugarUnit =
     Ok Canonical.Unit
 
+desugarTuple : (Frontend.Expr -> Result DesugarError Canonical.Expr) -> Frontend.Expr -> Frontend.Expr -> Result DesugarError Canonical.Expr
+desugarTuple recurse e1 e2 =
+    Result.map2 Canonical.Tuple
+        (recurse e1)
+        (recurse e2)
+
+
+desugarTuple3 : (Frontend.Expr -> Result DesugarError Canonical.Expr) -> Frontend.Expr -> Frontend.Expr -> Frontend.Expr -> Result DesugarError Canonical.Expr
+desugarTuple3 recurse e1 e2 e3 =
+    Result.map3 Canonical.Tuple3
+        (recurse e1)
+        (recurse e2)
+        (recurse e3)
 
 
 -- HELPERS

--- a/src/compiler/Stage/Emit/JavaScript.elm
+++ b/src/compiler/Stage/Emit/JavaScript.elm
@@ -74,6 +74,12 @@ emitExpr ( expr, _ ) =
         Unit ->
             """{type: "unit"}"""
 
+        Tuple e1 e2 ->
+            "[" ++ emitExpr e1 ++ "," ++ emitExpr e2 ++ "]"
+
+        Tuple3 e1 e2 e3 ->
+            "[" ++ emitExpr e1 ++ "," ++ emitExpr e2 ++ "," ++ emitExpr e3 ++ "]"
+
 
 emitTopLevelDeclaration : TopLevelDeclaration Backend.Expr -> String
 emitTopLevelDeclaration { module_, name, body } =

--- a/src/compiler/Stage/InferTypes.elm
+++ b/src/compiler/Stage/InferTypes.elm
@@ -68,6 +68,12 @@ inferExpr expr =
         (substituteAllTypes exprWithIds)
         substitutionMap
 
+        Typed.Tuple e1 e2 ->
+            generateEquations e1 ++ generateEquations e2
+
+        Typed.Tuple3 e1 e2 e3 ->
+            generateEquations e1 ++ generateEquations e2 ++ generateEquations e3
+
 
 {-| This function takes care of recursively applying `substituteType`
 from the bottom up.

--- a/src/compiler/Stage/InferTypes.elm
+++ b/src/compiler/Stage/InferTypes.elm
@@ -68,12 +68,6 @@ inferExpr expr =
         (substituteAllTypes exprWithIds)
         substitutionMap
 
-        Typed.Tuple e1 e2 ->
-            generateEquations e1 ++ generateEquations e2
-
-        Typed.Tuple3 e1 e2 e3 ->
-            generateEquations e1 ++ generateEquations e2 ++ generateEquations e3
-
 
 {-| This function takes care of recursively applying `substituteType`
 from the bottom up.
@@ -138,3 +132,14 @@ getBetterType substitutionMap type_ =
 
             Type.Unit ->
                 type_
+
+            Type.Tuple e1 e2 ->
+                Type.Tuple
+                    (getBetterType substitutionMap e1)
+                    (getBetterType substitutionMap e2)
+
+            Type.Tuple3 e1 e2 e3 ->
+                Type.Tuple3
+                    (getBetterType substitutionMap e1)
+                    (getBetterType substitutionMap e2)
+                    (getBetterType substitutionMap e3)

--- a/src/compiler/Stage/InferTypes/AssignIds.elm
+++ b/src/compiler/Stage/InferTypes/AssignIds.elm
@@ -186,15 +186,26 @@ assignIdsWith idSource expr =
                         items
             in
             wrap idSource1 (Typed.List items_)
-            Id.constant Typed.Unit
 
         Canonical.Tuple e1 e2 ->
-            Id.map2 Typed.Tuple
-                (toIdGenerator e1)
-                (toIdGenerator e2)
+            let
+                (e1_, idSource1) =
+                    assignIdsWith idSource e1
+
+                (e2_, idSource2) =
+                    assignIdsWith idSource1 e2
+            in
+                wrap idSource2 (Typed.Tuple e1_ e2_)
 
         Canonical.Tuple3 e1 e2 e3 ->
-            Id.map3 Typed.Tuple3
-                (toIdGenerator e1)
-                (toIdGenerator e2)
-                (toIdGenerator e3)
+            let
+                (e1_, idSource1) =
+                    assignIdsWith idSource e1
+
+                (e2_, idSource2) =
+                    assignIdsWith idSource1 e2
+
+                (e3_, idSource3) =
+                    assignIdsWith idSource1 e2
+            in
+                wrap idSource3 (Typed.Tuple3 e1_ e2_ e3_)

--- a/src/compiler/Stage/InferTypes/AssignIds.elm
+++ b/src/compiler/Stage/InferTypes/AssignIds.elm
@@ -206,6 +206,6 @@ assignIdsWith idSource expr =
                     assignIdsWith idSource1 e2
 
                 ( e3_, idSource3 ) =
-                    assignIdsWith idSource1 e2
+                    assignIdsWith idSource2 e3
             in
             wrap idSource3 (Typed.Tuple3 e1_ e2_ e3_)

--- a/src/compiler/Stage/InferTypes/AssignIds.elm
+++ b/src/compiler/Stage/InferTypes/AssignIds.elm
@@ -186,3 +186,15 @@ assignIdsWith idSource expr =
                         items
             in
             wrap idSource1 (Typed.List items_)
+            Id.constant Typed.Unit
+
+        Canonical.Tuple e1 e2 ->
+            Id.map2 Typed.Tuple
+                (toIdGenerator e1)
+                (toIdGenerator e2)
+
+        Canonical.Tuple3 e1 e2 e3 ->
+            Id.map3 Typed.Tuple3
+                (toIdGenerator e1)
+                (toIdGenerator e2)
+                (toIdGenerator e3)

--- a/src/compiler/Stage/InferTypes/AssignIds.elm
+++ b/src/compiler/Stage/InferTypes/AssignIds.elm
@@ -189,23 +189,23 @@ assignIdsWith idSource expr =
 
         Canonical.Tuple e1 e2 ->
             let
-                (e1_, idSource1) =
+                ( e1_, idSource1 ) =
                     assignIdsWith idSource e1
 
-                (e2_, idSource2) =
+                ( e2_, idSource2 ) =
                     assignIdsWith idSource1 e2
             in
-                wrap idSource2 (Typed.Tuple e1_ e2_)
+            wrap idSource2 (Typed.Tuple e1_ e2_)
 
         Canonical.Tuple3 e1 e2 e3 ->
             let
-                (e1_, idSource1) =
+                ( e1_, idSource1 ) =
                     assignIdsWith idSource e1
 
-                (e2_, idSource2) =
+                ( e2_, idSource2 ) =
                     assignIdsWith idSource1 e2
 
-                (e3_, idSource3) =
+                ( e3_, idSource3 ) =
                     assignIdsWith idSource1 e2
             in
-                wrap idSource3 (Typed.Tuple3 e1_ e2_ e3_)
+            wrap idSource3 (Typed.Tuple3 e1_ e2_ e3_)

--- a/src/compiler/Stage/InferTypes/GenerateEquations.elm
+++ b/src/compiler/Stage/InferTypes/GenerateEquations.elm
@@ -249,11 +249,52 @@ generateEquations idSource ( expr, type_ ) =
             , idSource2
             )
 
-        Typed.Tuple _ _ ->
-            ( [], idSource )
+        Typed.Tuple fst snd ->
+            let
+                ( _, fstType ) =
+                    fst
 
-        Typed.Tuple3 _ _ _ ->
-            ( [], idSource )
+                ( _, sndType ) =
+                    snd
+
+                ( fstEquations, idSource1 ) =
+                    generateEquations idSource fst
+
+                ( sndEquations, idSource2 ) =
+                    generateEquations idSource1 snd
+            in
+            ( equals type_ (Type.Tuple fstType sndType)
+                :: fstEquations
+                ++ sndEquations
+            , idSource2
+            )
+
+        Typed.Tuple3 fst snd trd ->
+            let
+                ( _, fstType ) =
+                    fst
+
+                ( _, sndType ) =
+                    snd
+
+                ( _, trdType ) =
+                    trd
+
+                ( fstEquations, idSource1 ) =
+                    generateEquations idSource fst
+
+                ( sndEquations, idSource2 ) =
+                    generateEquations idSource1 snd
+                
+                ( trdEquations, idSource3 ) =
+                    generateEquations idSource2 trd
+            in
+            ( equals type_ (Type.Tuple3 fstType sndType trdType)
+                :: fstEquations
+                ++ sndEquations
+                ++ trdEquations
+            , idSource3
+            )
 
 
 findArgumentUsages : VarName -> Typed.Expr -> List Typed.Expr

--- a/src/compiler/Stage/InferTypes/GenerateEquations.elm
+++ b/src/compiler/Stage/InferTypes/GenerateEquations.elm
@@ -285,7 +285,7 @@ generateEquations idSource ( expr, type_ ) =
 
                 ( sndEquations, idSource2 ) =
                     generateEquations idSource1 snd
-                
+
                 ( trdEquations, idSource3 ) =
                     generateEquations idSource2 trd
             in

--- a/src/compiler/Stage/InferTypes/GenerateEquations.elm
+++ b/src/compiler/Stage/InferTypes/GenerateEquations.elm
@@ -249,6 +249,12 @@ generateEquations idSource ( expr, type_ ) =
             , idSource2
             )
 
+        Typed.Tuple _ _ ->
+            ( [], idSource )
+
+        Typed.Tuple3 _ _ _ ->
+            ( [], idSource )
+
 
 findArgumentUsages : VarName -> Typed.Expr -> List Typed.Expr
 findArgumentUsages argument bodyExpr =

--- a/src/compiler/Stage/PrepareForBackend.elm
+++ b/src/compiler/Stage/PrepareForBackend.elm
@@ -191,3 +191,9 @@ findDependencies modules ( expr, _ ) =
 
         Unit ->
             []
+
+        Tuple e1 e2 ->
+            findDependencies_ e1 ++ findDependencies_ e2
+
+        Tuple3 e1 e2 e3 ->
+            findDependencies_ e1 ++ findDependencies_ e2 ++ findDependencies_ e3

--- a/tests/EmitTest.elm
+++ b/tests/EmitTest.elm
@@ -234,12 +234,17 @@ javascript =
                 (List.map runTest
                     [ ( "simple tuple", Tuple (typedInt 1) (typedInt 2), "[1,2]" )
                     , ( "mixed tuple", Tuple (typedInt 1) (typedString "hello"), "[1,\"hello\"]" )
+                    , ( "nested tuple", Tuple (typedInt 1) (typed (Tuple (typedInt 2) (typedInt 3))), "[1,[2,3]]" )
                     ]
                 )
             , describe "Tuple3"
                 (List.map runTest
                     [ ( "simple tuple3", Tuple3 (typedInt 1) (typedInt 2) (typedInt 3), "[1,2,3]" )
                     , ( "mixed tuple3", Tuple3 (typedInt 1) (typedString "hello") (typedBool True), "[1,\"hello\",true]" )
+                    , ( "nested tuple3"
+                      , Tuple3 (typedInt 1) (typedInt 2) (typed (Tuple3 (typedInt 3) (typedInt 4) (typedInt 5)))
+                      , "[1,2,[3,4,5]]"
+                      )
                     ]
                 )
             ]

--- a/tests/EmitTest.elm
+++ b/tests/EmitTest.elm
@@ -37,6 +37,14 @@ javascript =
             typedInt : Int -> Typed.Expr
             typedInt int =
                 typed (Literal (Int int))
+
+            typedString : String -> Typed.Expr
+            typedString str =
+                typed (Literal (String str))
+
+            typedBool : Bool -> Typed.Expr
+            typedBool bool =
+                typed (Literal (Bool bool))
           in
           describe "emitExpr_"
             [ describe "Int"
@@ -220,6 +228,18 @@ javascript =
                             }
                       , "((() => {const x = 2; const y = 3; return 1;})())"
                       )
+                    ]
+                )
+            , describe "Tuple"
+                (List.map runTest
+                    [ ( "simple tuple", Tuple (typedInt 1) (typedInt 2), "[1,2]" )
+                    , ( "mixed tuple", Tuple (typedInt 1) (typedString "hello"), "[1,\"hello\"]")
+                    ]
+                )
+            , describe "Tuple3"
+                (List.map runTest
+                    [ ( "simple tuple3", Tuple3 (typedInt 1) (typedInt 2) (typedInt 3), "[1,2,3]" )
+                    , ( "mixed tuple3", Tuple3 (typedInt 1) (typedString "hello") (typedBool True), "[1,\"hello\",true]" )
                     ]
                 )
             ]

--- a/tests/EmitTest.elm
+++ b/tests/EmitTest.elm
@@ -233,7 +233,7 @@ javascript =
             , describe "Tuple"
                 (List.map runTest
                     [ ( "simple tuple", Tuple (typedInt 1) (typedInt 2), "[1,2]" )
-                    , ( "mixed tuple", Tuple (typedInt 1) (typedString "hello"), "[1,\"hello\"]")
+                    , ( "mixed tuple", Tuple (typedInt 1) (typedString "hello"), "[1,\"hello\"]" )
                     ]
                 )
             , describe "Tuple3"

--- a/tests/InferTypesTest.elm
+++ b/tests/InferTypesTest.elm
@@ -52,9 +52,56 @@ typeInference =
                 ]
               )
             , ( "tuple"
-              , [ ( "two items"
-                  , Canonical.Tuple (Canonical.Literal (Bool True)) (Canonical.Literal (Int 1))
-                  , Ok ( Typed.Tuple ( Typed.Literal (Bool True), Type.Bool ) ( Typed.Literal (Int 1), Type.Int ), Type.Tuple Type.Bool Type.Int )
+              , [ ( "items with the same types"
+                  , Canonical.Tuple
+                        (Canonical.Literal (String "Hello"))
+                        (Canonical.Literal (String "Elm"))
+                  , Ok
+                        ( Typed.Tuple
+                            ( Typed.Literal (String "Hello"), Type.String )
+                            ( Typed.Literal (String "Elm"), Type.String )
+                        , Type.Tuple Type.String Type.String
+                        )
+                  )
+                , ( "items of different types"
+                  , Canonical.Tuple
+                        (Canonical.Literal (Bool True))
+                        (Canonical.Literal (Int 1))
+                  , Ok
+                        ( Typed.Tuple
+                            ( Typed.Literal (Bool True), Type.Bool )
+                            ( Typed.Literal (Int 1), Type.Int )
+                        , Type.Tuple Type.Bool Type.Int
+                        )
+                  )
+                ]
+              )
+            , ( "tuple3"
+              , [ ( "same types"
+                  , Canonical.Tuple3
+                        (Canonical.Literal (String "FP"))
+                        (Canonical.Literal (String "is"))
+                        (Canonical.Literal (String "good"))
+                  , Ok
+                        ( Typed.Tuple3
+                            ( Typed.Literal (String "FP"), Type.String )
+                            ( Typed.Literal (String "is"), Type.String )
+                            ( Typed.Literal (String "good"), Type.String )
+                        , Type.Tuple3 Type.String Type.String Type.String
+                        )
+                  )
+                , ( "different types"
+                  , Canonical.Tuple3
+                        (Canonical.Literal (Bool True))
+                        (Canonical.Literal (Int 1))
+                        (Canonical.Literal (Char 'h'))
+                  , Ok
+                        ( Typed.Tuple3
+                            ( Typed.Literal (Bool True), Type.Bool )
+                            ( Typed.Literal (Int 1), Type.Int )
+                            ( Typed.Literal (Char 'h'), Type.Char )
+                        , Type.Tuple3 Type.Bool Type.Int Type.Char
+                        )
                   )
                 ]
               )

--- a/tests/InferTypesTest.elm
+++ b/tests/InferTypesTest.elm
@@ -51,6 +51,13 @@ typeInference =
                   )
                 ]
               )
+            , ( "tuple"
+              , [ ( "two items"
+                  , Canonical.Tuple (Canonical.Literal (Bool True)) (Canonical.Literal (Int 1))
+                  , Ok ( Typed.Tuple ( Typed.Literal (Bool True), Type.Bool ) ( Typed.Literal (Int 1), Type.Int ), Type.Tuple Type.Bool Type.Int )
+                  )
+                ]
+              )
             ]
         )
 
@@ -137,17 +144,17 @@ typeToString =
             [ runTest
                 ( "tuple with two literals"
                 , Type.Tuple Type.Int Type.String
-                , "(Int,String)"
+                , "( Int, String )"
                 )
             , runTest
                 ( "tuple with two params"
                 , Type.Tuple (Type.Var 0) (Type.Var 1)
-                , "(a,b)"
+                , "( a, b )"
                 )
             , runTest
                 ( "tuple with tree params"
                 , Type.Tuple3 (Type.Var 0) (Type.Var 1) (Type.Var 2)
-                , "(a,b,c)"
+                , "( a, b, c )"
                 )
             ]
         ]

--- a/tests/InferTypesTest.elm
+++ b/tests/InferTypesTest.elm
@@ -133,6 +133,23 @@ typeToString =
                 , "The types `(List a) -> b` and `(List b) -> a` don't match."
                 )
             ]
+        , describe "tuples"
+            [ runTest
+                ( "tuple with two literals"
+                , Type.Tuple Type.Int Type.String
+                , "(Int,String)"
+                )
+            , runTest
+                ( "tuple with two params"
+                , Type.Tuple (Type.Var 0) (Type.Var 1)
+                , "(a,b)"
+                )
+            , runTest
+                ( "tuple with tree params"
+                , Type.Tuple3 (Type.Var 0) (Type.Var 1) (Type.Var 2)
+                , "(a,b,c)"
+                )
+            ]
         ]
 
 

--- a/tests/ParserTest.elm
+++ b/tests/ParserTest.elm
@@ -825,22 +825,22 @@ expr =
             , ( "tuple"
               , [ ( "without spaces"
                   , "(1,1)"
-                  , Ok (Tuple (Literal (Int 1)) (Literal (Int 1)))
+                  , Just (Tuple (Literal (Int 1)) (Literal (Int 1)))
                   )
                 , ( "with inner spaces"
                   , "( 1 , 1 )"
-                  , Ok (Tuple (Literal (Int 1)) (Literal (Int 1)))
+                  , Just (Tuple (Literal (Int 1)) (Literal (Int 1)))
                   )
                 ]
               )
             , ( "tuple3"
               , [ ( "without spaces"
                   , "(1,2,3)"
-                  , Ok (Tuple3 (Literal (Int 1)) (Literal (Int 2)) (Literal (Int 2)))
+                  , Just (Tuple3 (Literal (Int 1)) (Literal (Int 2)) (Literal (Int 2)))
                   )
                 , ( "with inner spaces"
                   , "( 1 , 2 , 3 )"
-                  , Ok (Tuple3 (Literal (Int 1)) (Literal (Int 2)) (Literal (Int 2)))
+                  , Just (Tuple3 (Literal (Int 1)) (Literal (Int 2)) (Literal (Int 2)))
                   )
                 ]
               )

--- a/tests/ParserTest.elm
+++ b/tests/ParserTest.elm
@@ -799,9 +799,24 @@ expr =
                 ]
               )
             , ( "tuple"
-              , [ ( "simple case"
+              , [ ( "without spaces"
                   , "(1,1)"
                   , Ok (Tuple (Literal (Int 1)) (Literal (Int 1)))
+                  )
+                , ( "with inner spaces"
+                  , "( 1 , 1 )"
+                  , Ok (Tuple (Literal (Int 1)) (Literal (Int 1)))
+                  )
+                ]
+              )
+            , ( "tuple3"
+              , [ ( "without spaces"
+                  , "(1,2,3)"
+                  , Ok (Tuple3 (Literal (Int 1)) (Literal (Int 2)) (Literal (Int 2)))
+                  )
+                , ( "with inner spaces"
+                  , "( 1 , 2 , 3 )"
+                  , Ok (Tuple3 (Literal (Int 1)) (Literal (Int 2)) (Literal (Int 2)))
                   )
                 ]
               )

--- a/tests/ParserTest.elm
+++ b/tests/ParserTest.elm
@@ -798,6 +798,13 @@ expr =
                   )
                 ]
               )
+            , ( "tuple"
+              , [ ( "simple case"
+                  , "(1,1)"
+                  , Ok (Tuple (Literal (Int 1)) (Literal (Int 1)))
+                  )
+                ]
+              )
             ]
         )
 


### PR DESCRIPTION
Hello friends!

Thanks for this project, looks quite interesting! :raised_hands: 
Here's my first iteration on introducing Tuple support.

Please let me know if this looks alright so far! I'll try to go through the checklist from #34 in this PR.

## Progress

* [x]  add `Tuple (Expr, Expr)` and `Triple (Expr, Expr, Expr)` constructors to `Frontend.Expr` type... solve any compiler errors that arise as a result (`emitExpr` etc)

* [x]  add tests that show all the various ways these can be written in. Don't think about newlines for now (those will be dealt with later), but write tests to see tuples work with and without spaces in between. Eg.:
    
    * [x]  `(1,2)`, `( 1, 2 )`
    * [x]  `(1,2,3)`, `( 1, 2, 3 )`

* [x]  implement type inference - it should be pretty straighforward:
    
    * [x]  if items have types A and B, the tuple has type `(A, B)`. (Yeah, you'll have to create new `Type` constructors to account for this)
    * [x]  similarly for 3-tuples ("triples" - I don't like that name though 🙁 ) - items with types A, B, C ➡️ 3-tuple has type `(A, B, C)`

* [x]  add emit tests too:
    
    * [x]  Elm's `(1, 2)` ➡️ JavaScript's `[1, 2]`, similarly with the 3-tuples

* [x]  implement emitting (`emitExpr`) to pass the emit tests above

* [x]  update the "what's done" table in README for tuples and 3-tuples: parser tests, type inference, emit and emit tests... but not parsers.