### PR TITLE
AST refactoring to extract position (Located Expr)

### DIFF
--- a/src/cli/Main.elm
+++ b/src/cli/Main.elm
@@ -274,7 +274,7 @@ handleReadFileSuccess filePath fileContents ({ project } as model) =
                         |> List.map (Common.expectedFilePath project.sourceDirectory)
                         |> Set.Any.fromList Common.filePathToString
 
-                newModules : Modules Frontend.Expr
+                newModules : Modules Frontend.LocatedExpr
                 newModules =
                     Dict.Any.update name
                         (always (Just parsedModule))

--- a/src/compiler/AST/Backend.elm
+++ b/src/compiler/AST/Backend.elm
@@ -1,6 +1,6 @@
 module AST.Backend exposing
-    ( Expr
-    , Graph
+    ( Graph
+    , LocatedExpr
     , ProjectFields
     )
 
@@ -13,9 +13,9 @@ type alias ProjectFields =
     { programGraph : Graph }
 
 
-type alias Expr =
-    Typed.Expr
+type alias LocatedExpr =
+    Typed.LocatedExpr
 
 
 type alias Graph =
-    Graph.Graph (TopLevelDeclaration Expr) ()
+    Graph.Graph (TopLevelDeclaration LocatedExpr) ()

--- a/src/compiler/AST/Canonical.elm
+++ b/src/compiler/AST/Canonical.elm
@@ -2,7 +2,6 @@ module AST.Canonical exposing
     ( Expr(..)
     , LocatedExpr
     , ProjectFields
-    , lambda
     , var
     )
 
@@ -53,16 +52,3 @@ var qualifier name =
         { qualifier = qualifier
         , name = name
         }
-
-
-lambda : VarName -> LocatedExpr -> LocatedExpr
-lambda argument body =
-    -- we use body's location
-    Located.map
-        (\_ ->
-            Lambda
-                { argument = argument
-                , body = body
-                }
-        )
-        body

--- a/src/compiler/AST/Canonical.elm
+++ b/src/compiler/AST/Canonical.elm
@@ -1,11 +1,13 @@
 module AST.Canonical exposing
     ( Expr(..)
+    , LocatedExpr
     , ProjectFields
     , lambda
     , var
     )
 
 import AST.Common.Literal exposing (Literal)
+import AST.Common.Located as Located exposing (Located)
 import Common.Types
     exposing
         ( Binding
@@ -17,7 +19,11 @@ import Dict.Any exposing (AnyDict)
 
 
 type alias ProjectFields =
-    { modules : Modules Expr }
+    { modules : Modules LocatedExpr }
+
+
+type alias LocatedExpr =
+    Located Expr
 
 
 {-| Differs from Frontend.Expr by:
@@ -30,15 +36,15 @@ type Expr
     = Literal Literal
     | Var { qualifier : ModuleName, name : VarName }
     | Argument VarName
-    | Plus Expr Expr
-    | Lambda { argument : VarName, body : Expr }
-    | Call { fn : Expr, argument : Expr }
-    | If { test : Expr, then_ : Expr, else_ : Expr }
-    | Let { bindings : AnyDict String VarName (Binding Expr), body : Expr }
-    | List (List Expr)
+    | Plus LocatedExpr LocatedExpr
+    | Lambda { argument : VarName, body : LocatedExpr }
+    | Call { fn : LocatedExpr, argument : LocatedExpr }
+    | If { test : LocatedExpr, then_ : LocatedExpr, else_ : LocatedExpr }
+    | Let { bindings : AnyDict String VarName (Binding LocatedExpr), body : LocatedExpr }
+    | List (List LocatedExpr)
     | Unit
-    | Tuple Expr Expr
-    | Tuple3 Expr Expr Expr
+    | Tuple LocatedExpr LocatedExpr
+    | Tuple3 LocatedExpr LocatedExpr LocatedExpr
 
 
 var : ModuleName -> VarName -> Expr
@@ -49,9 +55,14 @@ var qualifier name =
         }
 
 
-lambda : VarName -> Expr -> Expr
+lambda : VarName -> LocatedExpr -> LocatedExpr
 lambda argument body =
-    Lambda
-        { argument = argument
-        , body = body
-        }
+    -- we use body's location
+    Located.map
+        (\_ ->
+            Lambda
+                { argument = argument
+                , body = body
+                }
+        )
+        body

--- a/src/compiler/AST/Common/Located.elm
+++ b/src/compiler/AST/Common/Located.elm
@@ -6,6 +6,7 @@ module AST.Common.Located exposing
     , map
     , merge
     , parsed
+    , replaceWith
     , unwrap
     )
 
@@ -50,6 +51,11 @@ unwrap (Located _ expr) =
 map : (a -> b) -> Located a -> Located b
 map fn (Located region expr) =
     Located region (fn expr)
+
+
+replaceWith : b -> Located a -> Located b
+replaceWith expr (Located region _) =
+    Located region expr
 
 
 merge : (Located a -> Located a -> b) -> Located a -> Located a -> Located b

--- a/src/compiler/AST/Common/Located.elm
+++ b/src/compiler/AST/Common/Located.elm
@@ -1,0 +1,71 @@
+module AST.Common.Located exposing
+    ( Located
+    , Region
+    , getRegion
+    , located
+    , map
+    , merge
+    , parsed
+    , unwrap
+    )
+
+
+type Located expr
+    = Located Region expr
+
+
+type alias Region =
+    { start : Position
+    , end : Position
+    }
+
+
+type alias Position =
+    { row : Int
+    , col : Int
+    }
+
+
+{-| arguments order to facilitate parsing, see Parser.located
+-}
+parsed : ( Int, Int ) -> a -> ( Int, Int ) -> Located a
+parsed ( startRow, startCol ) value ( endRow, endCol ) =
+    Located
+        { start = Position startRow startCol
+        , end = Position endRow endCol
+        }
+        value
+
+
+located : Region -> expr -> Located expr
+located =
+    Located
+
+
+unwrap : Located a -> a
+unwrap (Located _ expr) =
+    expr
+
+
+map : (a -> b) -> Located a -> Located b
+map fn (Located region expr) =
+    Located region (fn expr)
+
+
+merge : (Located a -> Located a -> b) -> Located a -> Located a -> Located b
+merge fn l1 l2 =
+    Located
+        (mergeRegions (getRegion l1) (getRegion l2))
+        (fn l1 l2)
+
+
+getRegion : Located a -> Region
+getRegion (Located region _) =
+    region
+
+
+mergeRegions : Region -> Region -> Region
+mergeRegions r1 r2 =
+    { start = r1.start
+    , end = r2.end
+    }

--- a/src/compiler/AST/Frontend.elm
+++ b/src/compiler/AST/Frontend.elm
@@ -59,23 +59,6 @@ lambda arguments body =
         }
 
 
-
-{- Let's not get ahead of ourselves
-
-   | Let
-       { varName : VarName
-       , varBody : LocatedExpr
-       , body : LocatedExpr
-       }
-   | Fixpoint LocatedExpr
-   | Operator
-       { opName : VarName
-       , left : LocatedExpr
-       , right : LocatedExpr
-       }
--}
-
-
 {-| A helper for the Transform library.
 -}
 recurse : (Expr -> Expr) -> Expr -> Expr

--- a/src/compiler/AST/Frontend.elm
+++ b/src/compiler/AST/Frontend.elm
@@ -1,5 +1,6 @@
 module AST.Frontend exposing
     ( Expr(..)
+    , LocatedExpr
     , ProjectFields
     , lambda
     , transform
@@ -7,6 +8,7 @@ module AST.Frontend exposing
     )
 
 import AST.Common.Literal exposing (Literal)
+import AST.Common.Located as Located exposing (Located)
 import Common
 import Common.Types
     exposing
@@ -19,22 +21,26 @@ import Transform
 
 
 type alias ProjectFields =
-    { modules : Modules Expr }
+    { modules : Modules LocatedExpr }
+
+
+type alias LocatedExpr =
+    Located Expr
 
 
 type Expr
     = Literal Literal
     | Var { qualifier : Maybe ModuleName, name : VarName }
     | Argument VarName
-    | Plus Expr Expr
-    | Lambda { arguments : List VarName, body : Expr }
-    | Call { fn : Expr, argument : Expr }
-    | If { test : Expr, then_ : Expr, else_ : Expr }
-    | Let { bindings : List (Binding Expr), body : Expr }
-    | List (List Expr)
+    | Plus LocatedExpr LocatedExpr
+    | Lambda { arguments : List VarName, body : LocatedExpr }
+    | Call { fn : LocatedExpr, argument : LocatedExpr }
+    | If { test : LocatedExpr, then_ : LocatedExpr, else_ : LocatedExpr }
+    | Let { bindings : List (Binding LocatedExpr), body : LocatedExpr }
+    | List (List LocatedExpr)
     | Unit
-    | Tuple Expr Expr
-    | Tuple3 Expr Expr Expr
+    | Tuple LocatedExpr LocatedExpr
+    | Tuple3 LocatedExpr LocatedExpr LocatedExpr
 
 
 var : Maybe ModuleName -> VarName -> Expr
@@ -45,7 +51,7 @@ var qualifier name =
         }
 
 
-lambda : List VarName -> Expr -> Expr
+lambda : List VarName -> LocatedExpr -> Expr
 lambda arguments body =
     Lambda
         { arguments = arguments
@@ -58,14 +64,14 @@ lambda arguments body =
 
    | Let
        { varName : VarName
-       , varBody : Expr
-       , body : Expr
+       , varBody : LocatedExpr
+       , body : LocatedExpr
        }
-   | Fixpoint Expr
+   | Fixpoint LocatedExpr
    | Operator
        { opName : VarName
-       , left : Expr
-       , right : Expr
+       , left : LocatedExpr
+       , right : LocatedExpr
        }
 -}
 
@@ -85,41 +91,43 @@ recurse f expr =
             expr
 
         Plus e1 e2 ->
-            Plus (f e1) (f e2)
+            Plus
+                (Located.map f e1)
+                (Located.map f e2)
 
         Lambda ({ body } as lambda_) ->
-            Lambda { lambda_ | body = f body }
+            Lambda { lambda_ | body = Located.map f body }
 
         Call { fn, argument } ->
             Call
-                { fn = f fn
-                , argument = f argument
+                { fn = Located.map f fn
+                , argument = Located.map f argument
                 }
 
         If { test, then_, else_ } ->
             If
-                { test = f test
-                , then_ = f then_
-                , else_ = f else_
+                { test = Located.map f test
+                , then_ = Located.map f then_
+                , else_ = Located.map f else_
                 }
 
         Let { bindings, body } ->
             Let
-                { bindings = List.map (Common.mapBinding f) bindings
-                , body = f body
+                { bindings = List.map (Common.mapBinding (Located.map f)) bindings
+                , body = Located.map f body
                 }
 
         List items ->
-            List (List.map f items)
+            List (List.map (Located.map f) items)
 
         Unit ->
             expr
 
         Tuple e1 e2 ->
-            Tuple (f e1) (f e2)
+            Tuple (Located.map f e1) (Located.map f e2)
 
         Tuple3 e1 e2 e3 ->
-            Tuple3 (f e1) (f e2) (f e3)
+            Tuple3 (Located.map f e1) (Located.map f e2) (Located.map f e3)
 
 
 transform : (Expr -> Expr) -> Expr -> Expr

--- a/src/compiler/AST/Frontend.elm
+++ b/src/compiler/AST/Frontend.elm
@@ -63,6 +63,10 @@ lambda arguments body =
 -}
 recurse : (Expr -> Expr) -> Expr -> Expr
 recurse f expr =
+    let
+        f_ =
+            Located.map f
+    in
     case expr of
         Literal _ ->
             expr
@@ -75,42 +79,42 @@ recurse f expr =
 
         Plus e1 e2 ->
             Plus
-                (Located.map f e1)
-                (Located.map f e2)
+                (f_ e1)
+                (f_ e2)
 
         Lambda ({ body } as lambda_) ->
-            Lambda { lambda_ | body = Located.map f body }
+            Lambda { lambda_ | body = f_ body }
 
         Call { fn, argument } ->
             Call
-                { fn = Located.map f fn
-                , argument = Located.map f argument
+                { fn = f_ fn
+                , argument = f_ argument
                 }
 
         If { test, then_, else_ } ->
             If
-                { test = Located.map f test
-                , then_ = Located.map f then_
-                , else_ = Located.map f else_
+                { test = f_ test
+                , then_ = f_ then_
+                , else_ = f_ else_
                 }
 
         Let { bindings, body } ->
             Let
-                { bindings = List.map (Common.mapBinding (Located.map f)) bindings
-                , body = Located.map f body
+                { bindings = List.map (Common.mapBinding f_) bindings
+                , body = f_ body
                 }
 
         List items ->
-            List (List.map (Located.map f) items)
+            List (List.map f_ items)
 
         Unit ->
             expr
 
         Tuple e1 e2 ->
-            Tuple (Located.map f e1) (Located.map f e2)
+            Tuple (f_ e1) (f_ e2)
 
         Tuple3 e1 e2 e3 ->
-            Tuple3 (Located.map f e1) (Located.map f e2) (Located.map f e3)
+            Tuple3 (f_ e1) (f_ e2) (f_ e3)
 
 
 transform : (Expr -> Expr) -> Expr -> Expr

--- a/src/compiler/AST/Typed.elm
+++ b/src/compiler/AST/Typed.elm
@@ -32,7 +32,7 @@ type alias ProjectFields =
     { modules : Modules LocatedExpr }
 
 
-{-| Differs from Canonical.LocatedExpr by:
+{-| Differs from Canonical.Expr by:
 
   - being a tuple of the underlying Expr\_ type and its type
 

--- a/src/compiler/AST/Typed.elm
+++ b/src/compiler/AST/Typed.elm
@@ -32,6 +32,10 @@ type alias ProjectFields =
     { modules : Modules LocatedExpr }
 
 
+type alias LocatedExpr =
+    Located Expr
+
+
 {-| Differs from Canonical.Expr by:
 
   - being a tuple of the underlying Expr\_ type and its type
@@ -39,10 +43,6 @@ type alias ProjectFields =
 TODO make this opaque, add accessors etc.
 
 -}
-type alias LocatedExpr =
-    Located Expr
-
-
 type alias Expr =
     ( Expr_, Type )
 

--- a/src/compiler/Error.elm
+++ b/src/compiler/Error.elm
@@ -12,7 +12,6 @@ module Error exposing
     , toString
     )
 
-import AST.Common.Located exposing (Region)
 import AST.Common.Type as Type exposing (Type)
 import Common.Types
     exposing

--- a/src/compiler/Error.elm
+++ b/src/compiler/Error.elm
@@ -12,6 +12,7 @@ module Error exposing
     , toString
     )
 
+import AST.Common.Located exposing (Region)
 import AST.Common.Type as Type exposing (Type)
 import Common.Types
     exposing

--- a/src/compiler/Stage/Desugar.elm
+++ b/src/compiler/Stage/Desugar.elm
@@ -160,12 +160,11 @@ curryLambda : Canonical.LocatedExpr -> List VarName -> Canonical.LocatedExpr -> 
 curryLambda located arguments body =
     List.foldr
         (\argument body_ ->
-            Located.map
-                (\_ ->
-                    Canonical.Lambda
-                        { argument = argument
-                        , body = body_
-                        }
+            Located.replaceWith
+                (Canonical.Lambda
+                    { argument = argument
+                    , body = body_
+                    }
                 )
                 located
         )
@@ -248,10 +247,8 @@ qualifiedVarInAliasedModule modules thisModule maybeModuleName varName =
 locatedResultReturn : Frontend.LocatedExpr -> Canonical.Expr -> Result DesugarError Canonical.LocatedExpr
 locatedResultReturn located expr =
     Ok
-        (Located.map
-            (\_ ->
-                expr
-            )
+        (Located.replaceWith
+            expr
             located
         )
 
@@ -260,10 +257,8 @@ locatedResultMap : Frontend.LocatedExpr -> (a -> Canonical.Expr) -> Result Desug
 locatedResultMap located fn =
     Result.map
         (\expr ->
-            Located.map
-                (\_ ->
-                    fn expr
-                )
+            Located.replaceWith
+                (fn expr)
                 located
         )
 
@@ -272,10 +267,8 @@ locatedResultMap2 : Frontend.LocatedExpr -> (a -> b -> Canonical.Expr) -> Result
 locatedResultMap2 located fn =
     Result.map2
         (\expr1 expr2 ->
-            Located.map
-                (\_ ->
-                    fn expr1 expr2
-                )
+            Located.replaceWith
+                (fn expr1 expr2)
                 located
         )
 
@@ -284,9 +277,7 @@ locatedResultMap3 : Frontend.LocatedExpr -> (a -> b -> c -> Canonical.Expr) -> R
 locatedResultMap3 located fn =
     Result.map3
         (\expr1 expr2 expr3 ->
-            Located.map
-                (\_ ->
-                    fn expr1 expr2 expr3
-                )
+            Located.replaceWith
+                (fn expr1 expr2 expr3)
                 located
         )

--- a/src/compiler/Stage/Desugar.elm
+++ b/src/compiler/Stage/Desugar.elm
@@ -2,6 +2,7 @@ module Stage.Desugar exposing (desugar)
 
 import AST.Canonical as Canonical
 import AST.Common.Literal exposing (Literal)
+import AST.Common.Located as Located
 import AST.Frontend as Frontend
 import Basics.Extra exposing (flip)
 import Common
@@ -32,154 +33,114 @@ desugar project =
 of them. Thus, we get some separation of concerns - each pass only cares about
 a small subset of the whole process!
 -}
-desugarExpr : Modules Frontend.Expr -> Module Frontend.Expr -> Frontend.Expr -> Result DesugarError Canonical.Expr
-desugarExpr modules thisModule expr =
+desugarExpr :
+    Modules Frontend.LocatedExpr
+    -> Module Frontend.LocatedExpr
+    -> Frontend.LocatedExpr
+    -> Result DesugarError Canonical.LocatedExpr
+desugarExpr modules thisModule located =
     let
-        recurse expr_ =
-            desugarExpr modules thisModule expr_
+        recurse =
+            desugarExpr modules thisModule
+
+        return =
+            locatedResultReturn located
+
+        recurseMap =
+            locatedResultMap located
+
+        recurseMap2 =
+            locatedResultMap2 located
+
+        recurseMap3 =
+            locatedResultMap3 located
     in
-    case expr of
+    case Located.unwrap located of
         Frontend.Literal literal ->
-            desugarLiteral literal
+            Canonical.Literal literal
+                |> return
 
         Frontend.Var { qualifier, name } ->
-            desugarVar modules thisModule qualifier name
+            findModuleOfVar modules thisModule qualifier name
+                |> Result.fromMaybe
+                    (VarNotInEnvOfModule
+                        { var = ( qualifier, name )
+                        , module_ = thisModule.name
+                        }
+                    )
+                |> recurseMap (\moduleName -> Canonical.var moduleName name)
 
         Frontend.Argument varName ->
-            desugarArgument varName
+            Canonical.Argument varName
+                |> return
 
         Frontend.Plus e1 e2 ->
-            desugarPlus recurse e1 e2
+            recurseMap2 Canonical.Plus
+                (recurse e1)
+                (recurse e2)
 
         Frontend.Lambda { arguments, body } ->
-            desugarLambda recurse arguments body
+            recurse body
+                |> Result.map (curryLambda arguments)
 
         Frontend.Call { fn, argument } ->
-            desugarCall recurse fn argument
+            recurseMap2
+                (\fn_ argument_ ->
+                    Canonical.Call
+                        { fn = fn_
+                        , argument = argument_
+                        }
+                )
+                (recurse fn)
+                (recurse argument)
 
         Frontend.If { test, then_, else_ } ->
-            desugarIf recurse test then_ else_
+            recurseMap3
+                (\test_ then__ else__ ->
+                    Canonical.If
+                        { test = test_
+                        , then_ = then__
+                        , else_ = else__
+                        }
+                )
+                (recurse test)
+                (recurse then_)
+                (recurse else_)
 
         Frontend.Let { bindings, body } ->
-            desugarLet recurse bindings body
+            recurseMap2
+                (\bindings_ body_ ->
+                    Canonical.Let
+                        { bindings =
+                            bindings_
+                                |> List.map (\binding -> ( binding.name, binding ))
+                                |> Dict.Any.fromList Common.varNameToString
+                        , body = body_
+                        }
+                )
+                -- TODO a bit mouthful:
+                (Result.Extra.combine (List.map (Common.mapBinding recurse >> Common.combineBinding) bindings))
+                (recurse body)
 
         Frontend.List items ->
-            desugarList recurse items
-
-        Frontend.Unit ->
-            desugarUnit
+            List.map recurse items
+                |> List.foldr (Result.map2 (::)) (Ok [])
+                |> recurseMap Canonical.List
 
         Frontend.Tuple e1 e2 ->
-            desugarTuple recurse e1 e2
+            recurseMap2 Canonical.Tuple
+                (recurse e1)
+                (recurse e2)
 
         Frontend.Tuple3 e1 e2 e3 ->
-            desugarTuple3 recurse e1 e2 e3
+            recurseMap3 Canonical.Tuple3
+                (recurse e1)
+                (recurse e2)
+                (recurse e3)
 
-
-
--- DESUGAR PASSES
-
-
-desugarLiteral : Literal -> Result DesugarError Canonical.Expr
-desugarLiteral literal =
-    Ok (Canonical.Literal literal)
-
-
-desugarVar : Modules Frontend.Expr -> Module Frontend.Expr -> Maybe ModuleName -> VarName -> Result DesugarError Canonical.Expr
-desugarVar modules thisModule maybeModuleName varName =
-    findModuleOfVar modules thisModule maybeModuleName varName
-        |> Result.fromMaybe (VarNotInEnvOfModule { var = ( maybeModuleName, varName ), module_ = thisModule.name })
-        |> Result.map (\moduleName -> Canonical.var moduleName varName)
-
-
-desugarArgument : VarName -> Result DesugarError Canonical.Expr
-desugarArgument varName =
-    Ok (Canonical.Argument varName)
-
-
-desugarPlus : (Frontend.Expr -> Result DesugarError Canonical.Expr) -> Frontend.Expr -> Frontend.Expr -> Result DesugarError Canonical.Expr
-desugarPlus recurse e1 e2 =
-    Result.map2 Canonical.Plus
-        (recurse e1)
-        (recurse e2)
-
-
-desugarLambda : (Frontend.Expr -> Result DesugarError Canonical.Expr) -> List VarName -> Frontend.Expr -> Result DesugarError Canonical.Expr
-desugarLambda recurse arguments body =
-    recurse body
-        |> Result.map (curryLambda arguments)
-
-
-desugarCall : (Frontend.Expr -> Result DesugarError Canonical.Expr) -> Frontend.Expr -> Frontend.Expr -> Result DesugarError Canonical.Expr
-desugarCall recurse fn argument =
-    Result.map2
-        (\fn_ argument_ ->
-            Canonical.Call
-                { fn = fn_
-                , argument = argument_
-                }
-        )
-        (recurse fn)
-        (recurse argument)
-
-
-desugarIf : (Frontend.Expr -> Result DesugarError Canonical.Expr) -> Frontend.Expr -> Frontend.Expr -> Frontend.Expr -> Result DesugarError Canonical.Expr
-desugarIf recurse test then_ else_ =
-    Result.map3
-        (\test_ then__ else__ ->
-            Canonical.If
-                { test = test_
-                , then_ = then__
-                , else_ = else__
-                }
-        )
-        (recurse test)
-        (recurse then_)
-        (recurse else_)
-
-
-desugarLet : (Frontend.Expr -> Result DesugarError Canonical.Expr) -> List (Binding Frontend.Expr) -> Frontend.Expr -> Result DesugarError Canonical.Expr
-desugarLet recurse bindings body =
-    Result.map2
-        (\bindings_ body_ ->
-            Canonical.Let
-                { bindings =
-                    bindings_
-                        |> List.map (\binding -> ( binding.name, binding ))
-                        |> Dict.Any.fromList Common.varNameToString
-                , body = body_
-                }
-        )
-        -- TODO a bit mouthful:
-        (Result.Extra.combine (List.map (Common.mapBinding recurse >> Common.combineBinding) bindings))
-        (recurse body)
-
-
-desugarList : (Frontend.Expr -> Result DesugarError Canonical.Expr) -> List Frontend.Expr -> Result DesugarError Canonical.Expr
-desugarList recurse items =
-    List.map recurse items
-        |> List.foldr (Result.map2 (::)) (Ok [])
-        |> Result.map Canonical.List
-
-
-desugarUnit : Result DesugarError Canonical.Expr
-desugarUnit =
-    Ok Canonical.Unit
-
-
-desugarTuple : (Frontend.Expr -> Result DesugarError Canonical.Expr) -> Frontend.Expr -> Frontend.Expr -> Result DesugarError Canonical.Expr
-desugarTuple recurse e1 e2 =
-    Result.map2 Canonical.Tuple
-        (recurse e1)
-        (recurse e2)
-
-
-desugarTuple3 : (Frontend.Expr -> Result DesugarError Canonical.Expr) -> Frontend.Expr -> Frontend.Expr -> Frontend.Expr -> Result DesugarError Canonical.Expr
-desugarTuple3 recurse e1 e2 e3 =
-    Result.map3 Canonical.Tuple3
-        (recurse e1)
-        (recurse e2)
-        (recurse e3)
+        Frontend.Unit ->
+            Canonical.Unit
+                |> return
 
 
 
@@ -195,7 +156,7 @@ desugarTuple3 recurse e1 e2 e3 =
     Canonical.Lambda arg1 (Canonical.Lambda arg2 body)
 
 -}
-curryLambda : List VarName -> Canonical.Expr -> Canonical.Expr
+curryLambda : List VarName -> Canonical.LocatedExpr -> Canonical.LocatedExpr
 curryLambda arguments body =
     List.foldr Canonical.lambda body arguments
 
@@ -210,7 +171,7 @@ curryLambda arguments body =
 In all these cases we need to find the full unaliased module name of the var.
 
 -}
-findModuleOfVar : Modules Frontend.Expr -> Module Frontend.Expr -> Maybe ModuleName -> VarName -> Maybe ModuleName
+findModuleOfVar : Modules Frontend.LocatedExpr -> Module Frontend.LocatedExpr -> Maybe ModuleName -> VarName -> Maybe ModuleName
 findModuleOfVar modules thisModule maybeModuleName varName =
     {- TODO does this allow for some collisions by "returning early"?
        Should we check that exactly one is Just and the others are Nothing?
@@ -221,7 +182,7 @@ findModuleOfVar modules thisModule maybeModuleName varName =
         |> Maybe.Extra.orElseLazy (\() -> qualifiedVarInAliasedModule modules thisModule maybeModuleName varName)
 
 
-unqualifiedVarInThisModule : Module Frontend.Expr -> Maybe ModuleName -> VarName -> Maybe ModuleName
+unqualifiedVarInThisModule : Module Frontend.LocatedExpr -> Maybe ModuleName -> VarName -> Maybe ModuleName
 unqualifiedVarInThisModule thisModule maybeModuleName varName =
     if maybeModuleName == Nothing && Dict.Any.member varName thisModule.topLevelDeclarations then
         Just thisModule.name
@@ -230,7 +191,7 @@ unqualifiedVarInThisModule thisModule maybeModuleName varName =
         Nothing
 
 
-unqualifiedVarInImportedModule : Modules Frontend.Expr -> Module Frontend.Expr -> Maybe ModuleName -> VarName -> Maybe ModuleName
+unqualifiedVarInImportedModule : Modules Frontend.LocatedExpr -> Module Frontend.LocatedExpr -> Maybe ModuleName -> VarName -> Maybe ModuleName
 unqualifiedVarInImportedModule modules thisModule maybeModuleName varName =
     if maybeModuleName == Nothing then
         -- find a module which exposes that var
@@ -247,7 +208,7 @@ unqualifiedVarInImportedModule modules thisModule maybeModuleName varName =
         Nothing
 
 
-qualifiedVarInImportedModule : Modules Frontend.Expr -> Maybe ModuleName -> VarName -> Maybe ModuleName
+qualifiedVarInImportedModule : Modules Frontend.LocatedExpr -> Maybe ModuleName -> VarName -> Maybe ModuleName
 qualifiedVarInImportedModule modules maybeModuleName varName =
     maybeModuleName
         |> Maybe.andThen (flip Dict.Any.get modules)
@@ -262,7 +223,7 @@ qualifiedVarInImportedModule modules maybeModuleName varName =
         |> Maybe.withDefault Nothing
 
 
-qualifiedVarInAliasedModule : Modules Frontend.Expr -> Module Frontend.Expr -> Maybe ModuleName -> VarName -> Maybe ModuleName
+qualifiedVarInAliasedModule : Modules Frontend.LocatedExpr -> Module Frontend.LocatedExpr -> Maybe ModuleName -> VarName -> Maybe ModuleName
 qualifiedVarInAliasedModule modules thisModule maybeModuleName varName =
     let
         unaliasedModuleName =
@@ -270,3 +231,50 @@ qualifiedVarInAliasedModule modules thisModule maybeModuleName varName =
     in
     -- Reusing the existing functionality. TODO is this a good idea?
     qualifiedVarInImportedModule modules unaliasedModuleName varName
+
+
+locatedResultReturn : Frontend.LocatedExpr -> Canonical.Expr -> Result DesugarError Canonical.LocatedExpr
+locatedResultReturn located expr =
+    Ok
+        (Located.map
+            (\_ ->
+                expr
+            )
+            located
+        )
+
+
+locatedResultMap : Frontend.LocatedExpr -> (a -> Canonical.Expr) -> Result DesugarError a -> Result DesugarError Canonical.LocatedExpr
+locatedResultMap located fn =
+    Result.map
+        (\expr ->
+            Located.map
+                (\_ ->
+                    fn expr
+                )
+                located
+        )
+
+
+locatedResultMap2 : Frontend.LocatedExpr -> (a -> b -> Canonical.Expr) -> Result DesugarError a -> Result DesugarError b -> Result DesugarError Canonical.LocatedExpr
+locatedResultMap2 located fn =
+    Result.map2
+        (\expr1 expr2 ->
+            Located.map
+                (\_ ->
+                    fn expr1 expr2
+                )
+                located
+        )
+
+
+locatedResultMap3 : Frontend.LocatedExpr -> (a -> b -> c -> Canonical.Expr) -> Result DesugarError a -> Result DesugarError b -> Result DesugarError c -> Result DesugarError Canonical.LocatedExpr
+locatedResultMap3 located fn =
+    Result.map3
+        (\expr1 expr2 expr3 ->
+            Located.map
+                (\_ ->
+                    fn expr1 expr2 expr3
+                )
+                located
+        )

--- a/src/compiler/Stage/Desugar.elm
+++ b/src/compiler/Stage/Desugar.elm
@@ -81,7 +81,7 @@ desugarExpr modules thisModule located =
 
         Frontend.Lambda { arguments, body } ->
             recurse body
-                |> Result.map (curryLambda arguments)
+                |> Result.map (curryLambda located arguments)
 
         Frontend.Call { fn, argument } ->
             recurseMap2
@@ -156,8 +156,8 @@ desugarExpr modules thisModule located =
     Canonical.Lambda arg1 (Canonical.Lambda arg2 body)
 
 -}
-curryLambda : List VarName -> Canonical.LocatedExpr -> Canonical.LocatedExpr
-curryLambda arguments body =
+curryLambda : Canonical.LocatedExpr -> List VarName -> Canonical.LocatedExpr -> Canonical.LocatedExpr
+curryLambda located arguments body =
     List.foldr
         (\argument body_ ->
             Located.map
@@ -167,7 +167,7 @@ curryLambda arguments body =
                         , body = body_
                         }
                 )
-                body
+                located
         )
         body
         arguments

--- a/src/compiler/Stage/Desugar.elm
+++ b/src/compiler/Stage/Desugar.elm
@@ -158,7 +158,19 @@ desugarExpr modules thisModule located =
 -}
 curryLambda : List VarName -> Canonical.LocatedExpr -> Canonical.LocatedExpr
 curryLambda arguments body =
-    List.foldr Canonical.lambda body arguments
+    List.foldr
+        (\argument body_ ->
+            Located.map
+                (\_ ->
+                    Canonical.Lambda
+                        { argument = argument
+                        , body = body_
+                        }
+                )
+                body
+        )
+        body
+        arguments
 
 
 {-| We have roughly these options:

--- a/src/compiler/Stage/Desugar/Boilerplate.elm
+++ b/src/compiler/Stage/Desugar/Boilerplate.elm
@@ -17,7 +17,7 @@ import Error exposing (DesugarError)
 import Extra.Dict.Any
 
 
-desugarProject : (Module Frontend.Expr -> Frontend.Expr -> Result DesugarError Canonical.Expr) -> Project Frontend.ProjectFields -> Result DesugarError (Project Canonical.ProjectFields)
+desugarProject : (Module Frontend.LocatedExpr -> Frontend.LocatedExpr -> Result DesugarError Canonical.LocatedExpr) -> Project Frontend.ProjectFields -> Result DesugarError (Project Canonical.ProjectFields)
 desugarProject desugarExpr project =
     project.modules
         |> Dict.Any.map (always (desugarModule desugarExpr))
@@ -25,7 +25,7 @@ desugarProject desugarExpr project =
         |> Result.map (projectOfNewType project)
 
 
-projectOfNewType : Project Frontend.ProjectFields -> Modules Canonical.Expr -> Project Canonical.ProjectFields
+projectOfNewType : Project Frontend.ProjectFields -> Modules Canonical.LocatedExpr -> Project Canonical.ProjectFields
 projectOfNewType old modules =
     { elmJson = old.elmJson
     , mainFilePath = old.mainFilePath
@@ -37,7 +37,7 @@ projectOfNewType old modules =
     }
 
 
-desugarModule : (Module Frontend.Expr -> Frontend.Expr -> Result DesugarError Canonical.Expr) -> Module Frontend.Expr -> Result DesugarError (Module Canonical.Expr)
+desugarModule : (Module Frontend.LocatedExpr -> Frontend.LocatedExpr -> Result DesugarError Canonical.LocatedExpr) -> Module Frontend.LocatedExpr -> Result DesugarError (Module Canonical.LocatedExpr)
 desugarModule desugarExpr module_ =
     module_.topLevelDeclarations
         |> Dict.Any.map (always (desugarTopLevelDeclaration (desugarExpr module_)))
@@ -45,7 +45,7 @@ desugarModule desugarExpr module_ =
         |> Result.map (moduleOfNewType module_)
 
 
-moduleOfNewType : Module Frontend.Expr -> Dict_ VarName (TopLevelDeclaration Canonical.Expr) -> Module Canonical.Expr
+moduleOfNewType : Module Frontend.LocatedExpr -> Dict_ VarName (TopLevelDeclaration Canonical.LocatedExpr) -> Module Canonical.LocatedExpr
 moduleOfNewType old newDecls =
     { dependencies = old.dependencies
     , name = old.name
@@ -58,13 +58,13 @@ moduleOfNewType old newDecls =
     }
 
 
-desugarTopLevelDeclaration : (Frontend.Expr -> Result DesugarError Canonical.Expr) -> TopLevelDeclaration Frontend.Expr -> Result DesugarError (TopLevelDeclaration Canonical.Expr)
+desugarTopLevelDeclaration : (Frontend.LocatedExpr -> Result DesugarError Canonical.LocatedExpr) -> TopLevelDeclaration Frontend.LocatedExpr -> Result DesugarError (TopLevelDeclaration Canonical.LocatedExpr)
 desugarTopLevelDeclaration desugarExpr decl =
     desugarExpr decl.body
         |> Result.map (topLevelDeclarationOfNewType decl)
 
 
-topLevelDeclarationOfNewType : TopLevelDeclaration Frontend.Expr -> Canonical.Expr -> TopLevelDeclaration Canonical.Expr
+topLevelDeclarationOfNewType : TopLevelDeclaration Frontend.LocatedExpr -> Canonical.LocatedExpr -> TopLevelDeclaration Canonical.LocatedExpr
 topLevelDeclarationOfNewType old newBody =
     { name = old.name
     , module_ = old.module_

--- a/src/compiler/Stage/Emit.elm
+++ b/src/compiler/Stage/Emit.elm
@@ -31,7 +31,7 @@ emit project =
 {-| We want to be able to emit `main`. We only emit what's needed for that.
 Taken from the example in elm-community/graph README :sweat\_smile:
 -}
-findPathToMain : Project Backend.ProjectFields -> List (TopLevelDeclaration Backend.Expr)
+findPathToMain : Project Backend.ProjectFields -> List (TopLevelDeclaration Backend.LocatedExpr)
 findPathToMain { programGraph, mainModuleName } =
     Graph.guidedDfs
         Graph.alongIncomingEdges

--- a/src/compiler/Stage/Emit/JavaScript.elm
+++ b/src/compiler/Stage/Emit/JavaScript.elm
@@ -4,7 +4,7 @@ module Stage.Emit.JavaScript exposing (emitExpr, emitTopLevelDeclaration)
 
 import AST.Backend as Backend
 import AST.Common.Literal exposing (Literal(..))
-import AST.Typed exposing (Expr_(..), getExpr)
+import AST.Typed as Typed exposing (Expr_(..))
 import Common.Types
     exposing
         ( ModuleName(..)
@@ -16,7 +16,7 @@ import Dict.Any
 
 emitExpr : Backend.LocatedExpr -> String
 emitExpr located =
-    case getExpr located of
+    case Typed.getExpr located of
         Literal (Int int) ->
             String.fromInt int
 

--- a/src/compiler/Stage/Emit/JavaScript.elm
+++ b/src/compiler/Stage/Emit/JavaScript.elm
@@ -4,7 +4,7 @@ module Stage.Emit.JavaScript exposing (emitExpr, emitTopLevelDeclaration)
 
 import AST.Backend as Backend
 import AST.Common.Literal exposing (Literal(..))
-import AST.Typed exposing (Expr_(..))
+import AST.Typed exposing (Expr_(..), getExpr)
 import Common.Types
     exposing
         ( ModuleName(..)
@@ -14,9 +14,9 @@ import Common.Types
 import Dict.Any
 
 
-emitExpr : Backend.Expr -> String
-emitExpr ( expr, _ ) =
-    case expr of
+emitExpr : Backend.LocatedExpr -> String
+emitExpr located =
+    case getExpr located of
         Literal (Int int) ->
             String.fromInt int
 
@@ -81,7 +81,7 @@ emitExpr ( expr, _ ) =
             "[" ++ emitExpr e1 ++ "," ++ emitExpr e2 ++ "," ++ emitExpr e3 ++ "]"
 
 
-emitTopLevelDeclaration : TopLevelDeclaration Backend.Expr -> String
+emitTopLevelDeclaration : TopLevelDeclaration Backend.LocatedExpr -> String
 emitTopLevelDeclaration { module_, name, body } =
     "const "
         ++ mangleQualifiedVar module_ name

--- a/src/compiler/Stage/InferTypes.elm
+++ b/src/compiler/Stage/InferTypes.elm
@@ -35,10 +35,10 @@ inferTypes project =
 
 
 inferExpr : Canonical.LocatedExpr -> Result TypeError Typed.LocatedExpr
-inferExpr expr =
+inferExpr located =
     let
         ( exprWithIds, idSource ) =
-            AssignIds.assignIds expr
+            AssignIds.assignIds located
 
         typeEquations =
             GenerateEquations.generateEquations idSource exprWithIds

--- a/src/compiler/Stage/InferTypes.elm
+++ b/src/compiler/Stage/InferTypes.elm
@@ -1,6 +1,7 @@
 module Stage.InferTypes exposing (inferExpr, inferTypes)
 
 import AST.Canonical as Canonical
+import AST.Common.Located as Located
 import AST.Common.Type as Type exposing (Type)
 import AST.Typed as Typed
 import Common.Types exposing (Project)
@@ -33,7 +34,7 @@ inferTypes project =
         |> Result.mapError TypeError
 
 
-inferExpr : Canonical.Expr -> Result TypeError Typed.Expr
+inferExpr : Canonical.LocatedExpr -> Result TypeError Typed.LocatedExpr
 inferExpr expr =
     let
         ( exprWithIds, idSource ) =
@@ -72,18 +73,22 @@ inferExpr expr =
 {-| This function takes care of recursively applying `substituteType`
 from the bottom up.
 -}
-substituteAllTypes : Typed.Expr -> SubstitutionMap -> Typed.Expr
-substituteAllTypes expr substitutionMap =
+substituteAllTypes : Typed.LocatedExpr -> SubstitutionMap -> Typed.LocatedExpr
+substituteAllTypes located substitutionMap =
     Typed.transformOnce
         (substituteType substitutionMap)
-        expr
+        located
 
 
 {-| Only care about this level, don't recurse
 -}
-substituteType : SubstitutionMap -> Typed.Expr -> Typed.Expr
-substituteType substitutionMap ( expr, type_ ) =
-    ( expr, getBetterType substitutionMap type_ )
+substituteType : SubstitutionMap -> Typed.LocatedExpr -> Typed.LocatedExpr
+substituteType substitutionMap located =
+    Located.map
+        (\( expr, type_ ) ->
+            ( expr, getBetterType substitutionMap type_ )
+        )
+        located
 
 
 {-| Tries to resolve `Var 0`-like references through the SubstitutionMap.

--- a/src/compiler/Stage/InferTypes/AssignIds.elm
+++ b/src/compiler/Stage/InferTypes/AssignIds.elm
@@ -54,13 +54,13 @@ assignIds located =
 
 
 assignIdsWith : IdSource -> Canonical.LocatedExpr -> ( Typed.LocatedExpr, IdSource )
-assignIdsWith idSource located =
+assignIdsWith idSource locatedCanonicalExpr =
     let
-        ( located_, idSource_ ) =
-            assignIdsWithHelp idSource (Located.unwrap located)
+        ( typedExpr, idSource_ ) =
+            assignIdsWithHelp idSource (Located.unwrap locatedCanonicalExpr)
     in
     {- Keep location, for error context -}
-    ( Located.map (\_ -> located_) located
+    ( Located.replaceWith typedExpr locatedCanonicalExpr
     , idSource_
     )
 

--- a/src/compiler/Stage/InferTypes/AssignIds.elm
+++ b/src/compiler/Stage/InferTypes/AssignIds.elm
@@ -40,6 +40,7 @@ Output:
 -}
 
 import AST.Canonical as Canonical
+import AST.Common.Located as Located
 import AST.Common.Type as Type
 import AST.Typed as Typed
 import Common
@@ -47,32 +48,44 @@ import Dict.Any
 import Stage.InferTypes.IdSource as IdSource exposing (IdSource)
 
 
-assignIds : Canonical.Expr -> ( Typed.Expr, IdSource )
+assignIds : Canonical.LocatedExpr -> ( Typed.LocatedExpr, IdSource )
 assignIds expr =
     assignIdsWith IdSource.empty expr
 
 
-assignIdsWith : IdSource -> Canonical.Expr -> ( Typed.Expr, IdSource )
+assignIdsWith : IdSource -> Canonical.LocatedExpr -> ( Typed.LocatedExpr, IdSource )
 assignIdsWith idSource expr =
     let
-        wrap : IdSource -> Typed.Expr_ -> ( Typed.Expr, IdSource )
-        wrap idSource_ expr_ =
-            IdSource.one idSource_ (\id -> ( expr_, Type.Var id ))
+        ( expr_, idSource_ ) =
+            assignIdsWithHelp idSource (Located.unwrap expr)
     in
+    {- Keep location, for error context -}
+    ( Located.map (\_ -> expr_) expr
+    , idSource_
+    )
+
+
+assignId : IdSource -> Typed.Expr_ -> ( Typed.Expr, IdSource )
+assignId idSource expr =
+    IdSource.one idSource (\id -> ( expr, Type.Var id ))
+
+
+assignIdsWithHelp : IdSource -> Canonical.Expr -> ( Typed.Expr, IdSource )
+assignIdsWithHelp idSource expr =
     case expr of
         {- With literals, we could plug their final type in right here
            (no solving needed!) but let's be uniform and do everything through
            the constraint solver in stages 2 and 3.
         -}
         Canonical.Literal literal ->
-            wrap idSource (Typed.Literal literal)
+            assignId idSource (Typed.Literal literal)
 
         -- We remember argument's IDs so that we can later use them in Lambda
         Canonical.Argument name ->
-            wrap idSource (Typed.Argument name)
+            assignId idSource (Typed.Argument name)
 
         Canonical.Var name ->
-            wrap idSource (Typed.Var name)
+            assignId idSource (Typed.Var name)
 
         Canonical.Plus e1 e2 ->
             let
@@ -82,14 +95,14 @@ assignIdsWith idSource expr =
                 ( e2_, idSource2 ) =
                     assignIdsWith idSource1 e2
             in
-            wrap idSource2 (Typed.Plus e1_ e2_)
+            assignId idSource2 (Typed.Plus e1_ e2_)
 
         Canonical.Lambda { argument, body } ->
             let
                 ( body_, idSource1 ) =
                     assignIdsWith idSource body
             in
-            wrap idSource1 (Typed.lambda argument body_)
+            assignId idSource1 (Typed.lambda argument body_)
 
         Canonical.Call { fn, argument } ->
             let
@@ -99,7 +112,7 @@ assignIdsWith idSource expr =
                 ( argument_, idSource2 ) =
                     assignIdsWith idSource1 argument
             in
-            wrap idSource2
+            assignId idSource2
                 (Typed.Call
                     { fn = fn_
                     , argument = argument_
@@ -117,7 +130,7 @@ assignIdsWith idSource expr =
                 ( else__, idSource3 ) =
                     assignIdsWith idSource2 else_
             in
-            wrap idSource3
+            assignId idSource3
                 (Typed.If
                     { test = test_
                     , then_ = then__
@@ -153,7 +166,7 @@ assignIdsWith idSource expr =
                         ( [], idSource1 )
                         bindingsList
             in
-            wrap idSource2
+            assignId idSource2
                 (Typed.let_
                     (Dict.Any.fromList
                         Common.varNameToString
@@ -167,7 +180,7 @@ assignIdsWith idSource expr =
                 )
 
         Canonical.Unit ->
-            wrap idSource Typed.Unit
+            assignId idSource Typed.Unit
 
         Canonical.List items ->
             let
@@ -185,7 +198,7 @@ assignIdsWith idSource expr =
                         ( [], idSource )
                         items
             in
-            wrap idSource1 (Typed.List items_)
+            assignId idSource1 (Typed.List items_)
 
         Canonical.Tuple e1 e2 ->
             let
@@ -195,7 +208,7 @@ assignIdsWith idSource expr =
                 ( e2_, idSource2 ) =
                     assignIdsWith idSource1 e2
             in
-            wrap idSource2 (Typed.Tuple e1_ e2_)
+            assignId idSource2 (Typed.Tuple e1_ e2_)
 
         Canonical.Tuple3 e1 e2 e3 ->
             let
@@ -208,4 +221,4 @@ assignIdsWith idSource expr =
                 ( e3_, idSource3 ) =
                     assignIdsWith idSource2 e3
             in
-            wrap idSource3 (Typed.Tuple3 e1_ e2_ e3_)
+            assignId idSource3 (Typed.Tuple3 e1_ e2_ e3_)

--- a/src/compiler/Stage/InferTypes/AssignIds.elm
+++ b/src/compiler/Stage/InferTypes/AssignIds.elm
@@ -49,30 +49,30 @@ import Stage.InferTypes.IdSource as IdSource exposing (IdSource)
 
 
 assignIds : Canonical.LocatedExpr -> ( Typed.LocatedExpr, IdSource )
-assignIds expr =
-    assignIdsWith IdSource.empty expr
+assignIds located =
+    assignIdsWith IdSource.empty located
 
 
 assignIdsWith : IdSource -> Canonical.LocatedExpr -> ( Typed.LocatedExpr, IdSource )
-assignIdsWith idSource expr =
+assignIdsWith idSource located =
     let
-        ( expr_, idSource_ ) =
-            assignIdsWithHelp idSource (Located.unwrap expr)
+        ( located_, idSource_ ) =
+            assignIdsWithHelp idSource (Located.unwrap located)
     in
     {- Keep location, for error context -}
-    ( Located.map (\_ -> expr_) expr
+    ( Located.map (\_ -> located_) located
     , idSource_
     )
 
 
 assignId : IdSource -> Typed.Expr_ -> ( Typed.Expr, IdSource )
-assignId idSource expr =
-    IdSource.one idSource (\id -> ( expr, Type.Var id ))
+assignId idSource located =
+    IdSource.one idSource (\id -> ( located, Type.Var id ))
 
 
 assignIdsWithHelp : IdSource -> Canonical.Expr -> ( Typed.Expr, IdSource )
-assignIdsWithHelp idSource expr =
-    case expr of
+assignIdsWithHelp idSource located =
+    case located of
         {- With literals, we could plug their final type in right here
            (no solving needed!) but let's be uniform and do everything through
            the constraint solver in stages 2 and 3.

--- a/src/compiler/Stage/InferTypes/Boilerplate.elm
+++ b/src/compiler/Stage/InferTypes/Boilerplate.elm
@@ -17,7 +17,7 @@ import Error exposing (TypeError)
 import Extra.Dict.Any
 
 
-inferProject : (Canonical.Expr -> Result TypeError Typed.Expr) -> Project Canonical.ProjectFields -> Result TypeError (Project Typed.ProjectFields)
+inferProject : (Canonical.LocatedExpr -> Result TypeError Typed.LocatedExpr) -> Project Canonical.ProjectFields -> Result TypeError (Project Typed.ProjectFields)
 inferProject inferExpr project =
     project.modules
         |> Dict.Any.map (always (inferModule inferExpr))
@@ -25,7 +25,7 @@ inferProject inferExpr project =
         |> Result.map (projectOfNewType project)
 
 
-projectOfNewType : Project Canonical.ProjectFields -> Modules Typed.Expr -> Project Typed.ProjectFields
+projectOfNewType : Project Canonical.ProjectFields -> Modules Typed.LocatedExpr -> Project Typed.ProjectFields
 projectOfNewType old modules =
     { elmJson = old.elmJson
     , mainFilePath = old.mainFilePath
@@ -37,7 +37,7 @@ projectOfNewType old modules =
     }
 
 
-inferModule : (Canonical.Expr -> Result TypeError Typed.Expr) -> Module Canonical.Expr -> Result TypeError (Module Typed.Expr)
+inferModule : (Canonical.LocatedExpr -> Result TypeError Typed.LocatedExpr) -> Module Canonical.LocatedExpr -> Result TypeError (Module Typed.LocatedExpr)
 inferModule inferExpr module_ =
     module_.topLevelDeclarations
         |> Dict.Any.map (always (inferTopLevelDeclaration inferExpr))
@@ -45,7 +45,7 @@ inferModule inferExpr module_ =
         |> Result.map (moduleOfNewType module_)
 
 
-moduleOfNewType : Module Canonical.Expr -> Dict_ VarName (TopLevelDeclaration Typed.Expr) -> Module Typed.Expr
+moduleOfNewType : Module Canonical.LocatedExpr -> Dict_ VarName (TopLevelDeclaration Typed.LocatedExpr) -> Module Typed.LocatedExpr
 moduleOfNewType old newDecls =
     { dependencies = old.dependencies
     , name = old.name
@@ -58,13 +58,13 @@ moduleOfNewType old newDecls =
     }
 
 
-inferTopLevelDeclaration : (Canonical.Expr -> Result TypeError Typed.Expr) -> TopLevelDeclaration Canonical.Expr -> Result TypeError (TopLevelDeclaration Typed.Expr)
+inferTopLevelDeclaration : (Canonical.LocatedExpr -> Result TypeError Typed.LocatedExpr) -> TopLevelDeclaration Canonical.LocatedExpr -> Result TypeError (TopLevelDeclaration Typed.LocatedExpr)
 inferTopLevelDeclaration inferExpr decl =
     inferExpr decl.body
         |> Result.map (topLevelDeclarationOfNewType decl)
 
 
-topLevelDeclarationOfNewType : TopLevelDeclaration Canonical.Expr -> Typed.Expr -> TopLevelDeclaration Typed.Expr
+topLevelDeclarationOfNewType : TopLevelDeclaration Canonical.LocatedExpr -> Typed.LocatedExpr -> TopLevelDeclaration Typed.LocatedExpr
 topLevelDeclarationOfNewType old newBody =
     { name = old.name
     , module_ = old.module_

--- a/src/compiler/Stage/InferTypes/GenerateEquations.elm
+++ b/src/compiler/Stage/InferTypes/GenerateEquations.elm
@@ -41,10 +41,10 @@ import Transform
 
 
 generateEquations : IdSource -> Typed.LocatedExpr -> ( List TypeEquation, IdSource )
-generateEquations idSource located_ =
+generateEquations idSource located =
     let
         ( expr, type_ ) =
-            Located.unwrap located_
+            Located.unwrap located
     in
     case expr of
         Typed.Literal (Literal.Int _) ->

--- a/src/compiler/Stage/InferTypes/GenerateEquations.elm
+++ b/src/compiler/Stage/InferTypes/GenerateEquations.elm
@@ -306,18 +306,18 @@ generateEquations idSource located =
 
 
 findArgumentUsages : VarName -> Typed.LocatedExpr -> List Typed.LocatedExpr
-findArgumentUsages argument located =
-    located
+findArgumentUsages argument bodyExpr =
+    bodyExpr
         |> Transform.children Typed.recursiveChildren
         |> List.filter (Typed.isArgument argument)
 
 
 generateArgumentUsageEquations : Int -> List Typed.LocatedExpr -> List TypeEquation
-generateArgumentUsageEquations argumentId exprs =
+generateArgumentUsageEquations argumentId usages =
     let
         argumentType =
             Type.Var argumentId
     in
     List.map
-        (\l -> equals (Typed.getType l) argumentType)
-        exprs
+        (Typed.getType >> equals argumentType)
+        usages

--- a/src/compiler/Stage/InferTypes/GenerateEquations.elm
+++ b/src/compiler/Stage/InferTypes/GenerateEquations.elm
@@ -30,6 +30,7 @@ subexpression.
 -}
 
 import AST.Common.Literal as Literal
+import AST.Common.Located as Located
 import AST.Common.Type as Type
 import AST.Typed as Typed
 import Common.Types exposing (VarName)
@@ -39,8 +40,12 @@ import Stage.InferTypes.TypeEquation exposing (TypeEquation, equals)
 import Transform
 
 
-generateEquations : IdSource -> Typed.Expr -> ( List TypeEquation, IdSource )
-generateEquations idSource ( expr, type_ ) =
+generateEquations : IdSource -> Typed.LocatedExpr -> ( List TypeEquation, IdSource )
+generateEquations idSource located_ =
+    let
+        ( expr, type_ ) =
+            Located.unwrap located_
+    in
     case expr of
         Typed.Literal (Literal.Int _) ->
             -- integer is an integer ¯\_(ツ)_/¯
@@ -83,10 +88,10 @@ generateEquations idSource ( expr, type_ ) =
         Typed.Plus left right ->
             let
                 ( _, leftType ) =
-                    left
+                    Located.unwrap left
 
                 ( _, rightType ) =
-                    right
+                    Located.unwrap right
 
                 ( leftEquations, idSource1 ) =
                     generateEquations idSource left
@@ -107,7 +112,7 @@ generateEquations idSource ( expr, type_ ) =
         Typed.Lambda { body, argument } ->
             let
                 ( _, bodyType ) =
-                    body
+                    Located.unwrap body
 
                 ( argumentId, idSource1 ) =
                     IdSource.increment idSource
@@ -132,10 +137,10 @@ generateEquations idSource ( expr, type_ ) =
         Typed.Call { fn, argument } ->
             let
                 ( _, fnType ) =
-                    fn
+                    Located.unwrap fn
 
                 ( _, argumentType ) =
-                    argument
+                    Located.unwrap argument
 
                 ( fnEquations, idSource1 ) =
                     generateEquations idSource fn
@@ -154,13 +159,13 @@ generateEquations idSource ( expr, type_ ) =
         Typed.If { test, then_, else_ } ->
             let
                 ( _, testType ) =
-                    test
+                    Located.unwrap test
 
                 ( _, thenType ) =
-                    then_
+                    Located.unwrap then_
 
                 ( _, elseType ) =
-                    else_
+                    Located.unwrap else_
 
                 ( testEquations, idSource1 ) =
                     generateEquations idSource test
@@ -185,7 +190,7 @@ generateEquations idSource ( expr, type_ ) =
         Typed.Let { bindings, body } ->
             let
                 ( _, bodyType ) =
-                    body
+                    Located.unwrap body
 
                 ( bodyEquations, idSource1 ) =
                     generateEquations idSource body
@@ -228,8 +233,11 @@ generateEquations idSource ( expr, type_ ) =
 
                 ( bodyEquations, idSource2 ) =
                     List.foldr
-                        (\(( _, itemType ) as item) ( acc, currentIdSource ) ->
+                        (\item ( acc, currentIdSource ) ->
                             let
+                                ( _, itemType ) =
+                                    Located.unwrap item
+
                                 ( equations, nextIdSource ) =
                                     generateEquations currentIdSource item
                             in
@@ -252,10 +260,10 @@ generateEquations idSource ( expr, type_ ) =
         Typed.Tuple fst snd ->
             let
                 ( _, fstType ) =
-                    fst
+                    Located.unwrap fst
 
                 ( _, sndType ) =
-                    snd
+                    Located.unwrap snd
 
                 ( fstEquations, idSource1 ) =
                     generateEquations idSource fst
@@ -272,13 +280,13 @@ generateEquations idSource ( expr, type_ ) =
         Typed.Tuple3 fst snd trd ->
             let
                 ( _, fstType ) =
-                    fst
+                    Located.unwrap fst
 
                 ( _, sndType ) =
-                    snd
+                    Located.unwrap snd
 
                 ( _, trdType ) =
-                    trd
+                    Located.unwrap trd
 
                 ( fstEquations, idSource1 ) =
                     generateEquations idSource fst
@@ -297,19 +305,19 @@ generateEquations idSource ( expr, type_ ) =
             )
 
 
-findArgumentUsages : VarName -> Typed.Expr -> List Typed.Expr
-findArgumentUsages argument bodyExpr =
-    bodyExpr
+findArgumentUsages : VarName -> Typed.LocatedExpr -> List Typed.LocatedExpr
+findArgumentUsages argument located =
+    located
         |> Transform.children Typed.recursiveChildren
         |> List.filter (Typed.isArgument argument)
 
 
-generateArgumentUsageEquations : Int -> List Typed.Expr -> List TypeEquation
-generateArgumentUsageEquations argumentId usages =
+generateArgumentUsageEquations : Int -> List Typed.LocatedExpr -> List TypeEquation
+generateArgumentUsageEquations argumentId exprs =
     let
         argumentType =
             Type.Var argumentId
     in
     List.map
-        (\( _, usageType ) -> equals usageType argumentType)
-        usages
+        (\l -> equals (Typed.getType l) argumentType)
+        exprs

--- a/src/compiler/Stage/Optimize.elm
+++ b/src/compiler/Stage/Optimize.elm
@@ -14,11 +14,12 @@ optimize project =
 
 
 optimizeExpr : Typed.LocatedExpr -> Typed.LocatedExpr
-optimizeExpr =
+optimizeExpr located =
     Typed.transformAll
         [ optimizePlus
         , optimizeIfLiteralBool
         ]
+        located
 
 
 optimizePlus : Typed.LocatedExpr -> Maybe Typed.LocatedExpr

--- a/src/compiler/Stage/Optimize.elm
+++ b/src/compiler/Stage/Optimize.elm
@@ -1,6 +1,7 @@
 module Stage.Optimize exposing (optimize, optimizeExpr)
 
 import AST.Common.Literal as Literal
+import AST.Common.Located as Located
 import AST.Common.Type as Type
 import AST.Typed as Typed
 import Common.Types exposing (Project)
@@ -12,34 +13,43 @@ optimize project =
     Boilerplate.optimizeProject optimizeExpr project
 
 
-optimizeExpr : Typed.Expr -> Typed.Expr
-optimizeExpr expr =
+optimizeExpr : Typed.LocatedExpr -> Typed.LocatedExpr
+optimizeExpr =
     Typed.transformAll
         [ optimizePlus
         , optimizeIfLiteralBool
         ]
-        expr
 
 
-optimizePlus : Typed.Expr -> Maybe Typed.Expr
-optimizePlus ( expr, _ ) =
-    case expr of
-        Typed.Plus ( Typed.Literal (Literal.Int left), _ ) ( Typed.Literal (Literal.Int right), _ ) ->
-            Just
-                ( Typed.Literal (Literal.Int (left + right))
-                , Type.Int
-                )
+optimizePlus : Typed.LocatedExpr -> Maybe Typed.LocatedExpr
+optimizePlus expr =
+    case Typed.getExpr expr of
+        Typed.Plus l r ->
+            case ( Typed.getExpr l, Typed.getExpr r ) of
+                ( Typed.Literal (Literal.Int left), Typed.Literal (Literal.Int right) ) ->
+                    Just
+                        (Located.map
+                            (\_ ->
+                                ( Typed.Literal (Literal.Int (left + right))
+                                , Type.Int
+                                )
+                            )
+                            expr
+                        )
+
+                _ ->
+                    Nothing
 
         _ ->
             Nothing
 
 
-optimizeIfLiteralBool : Typed.Expr -> Maybe Typed.Expr
-optimizeIfLiteralBool ( expr, _ ) =
-    case expr of
+optimizeIfLiteralBool : Typed.LocatedExpr -> Maybe Typed.LocatedExpr
+optimizeIfLiteralBool expr =
+    case Typed.getExpr expr of
         Typed.If { test, then_, else_ } ->
-            case test of
-                ( Typed.Literal (Literal.Bool bool), _ ) ->
+            case Typed.getExpr test of
+                Typed.Literal (Literal.Bool bool) ->
                     Just
                         (if bool then
                             then_

--- a/src/compiler/Stage/Optimize.elm
+++ b/src/compiler/Stage/Optimize.elm
@@ -28,11 +28,9 @@ optimizePlus located =
             case ( Typed.getExpr l, Typed.getExpr r ) of
                 ( Typed.Literal (Literal.Int left), Typed.Literal (Literal.Int right) ) ->
                     Just
-                        (Located.map
-                            (\_ ->
-                                ( Typed.Literal (Literal.Int (left + right))
-                                , Type.Int
-                                )
+                        (Located.replaceWith
+                            ( Typed.Literal (Literal.Int (left + right))
+                            , Type.Int
                             )
                             located
                         )

--- a/src/compiler/Stage/Optimize.elm
+++ b/src/compiler/Stage/Optimize.elm
@@ -22,8 +22,8 @@ optimizeExpr =
 
 
 optimizePlus : Typed.LocatedExpr -> Maybe Typed.LocatedExpr
-optimizePlus expr =
-    case Typed.getExpr expr of
+optimizePlus located =
+    case Typed.getExpr located of
         Typed.Plus l r ->
             case ( Typed.getExpr l, Typed.getExpr r ) of
                 ( Typed.Literal (Literal.Int left), Typed.Literal (Literal.Int right) ) ->
@@ -34,7 +34,7 @@ optimizePlus expr =
                                 , Type.Int
                                 )
                             )
-                            expr
+                            located
                         )
 
                 _ ->
@@ -45,8 +45,8 @@ optimizePlus expr =
 
 
 optimizeIfLiteralBool : Typed.LocatedExpr -> Maybe Typed.LocatedExpr
-optimizeIfLiteralBool expr =
-    case Typed.getExpr expr of
+optimizeIfLiteralBool located =
+    case Typed.getExpr located of
         Typed.If { test, then_, else_ } ->
             case Typed.getExpr test of
                 Typed.Literal (Literal.Bool bool) ->

--- a/src/compiler/Stage/Optimize/Boilerplate.elm
+++ b/src/compiler/Stage/Optimize/Boilerplate.elm
@@ -13,36 +13,36 @@ import Common.Types
 import Dict.Any
 
 
-optimizeProject : (Typed.Expr -> Typed.Expr) -> Project Typed.ProjectFields -> Project Typed.ProjectFields
+optimizeProject : (Typed.LocatedExpr -> Typed.LocatedExpr) -> Project Typed.ProjectFields -> Project Typed.ProjectFields
 optimizeProject optimizeExpr project =
     project.modules
         |> Dict.Any.map (always (optimizeModule optimizeExpr))
         |> asModulesIn project
 
 
-asModulesIn : Project Typed.ProjectFields -> Modules Typed.Expr -> Project Typed.ProjectFields
+asModulesIn : Project Typed.ProjectFields -> Modules Typed.LocatedExpr -> Project Typed.ProjectFields
 asModulesIn project modules =
     { project | modules = modules }
 
 
-optimizeModule : (Typed.Expr -> Typed.Expr) -> Module Typed.Expr -> Module Typed.Expr
+optimizeModule : (Typed.LocatedExpr -> Typed.LocatedExpr) -> Module Typed.LocatedExpr -> Module Typed.LocatedExpr
 optimizeModule optimizeExpr module_ =
     module_.topLevelDeclarations
         |> Dict.Any.map (always (optimizeTopLevelDeclaration optimizeExpr))
         |> asTopLevelDeclarationsIn module_
 
 
-asTopLevelDeclarationsIn : Module Typed.Expr -> Dict_ VarName (TopLevelDeclaration Typed.Expr) -> Module Typed.Expr
+asTopLevelDeclarationsIn : Module Typed.LocatedExpr -> Dict_ VarName (TopLevelDeclaration Typed.LocatedExpr) -> Module Typed.LocatedExpr
 asTopLevelDeclarationsIn module_ topLevelDeclarations =
     { module_ | topLevelDeclarations = topLevelDeclarations }
 
 
-optimizeTopLevelDeclaration : (Typed.Expr -> Typed.Expr) -> TopLevelDeclaration Typed.Expr -> TopLevelDeclaration Typed.Expr
+optimizeTopLevelDeclaration : (Typed.LocatedExpr -> Typed.LocatedExpr) -> TopLevelDeclaration Typed.LocatedExpr -> TopLevelDeclaration Typed.LocatedExpr
 optimizeTopLevelDeclaration optimizeExpr decl =
     optimizeExpr decl.body
         |> asBodyIn decl
 
 
-asBodyIn : TopLevelDeclaration Typed.Expr -> Typed.Expr -> TopLevelDeclaration Typed.Expr
+asBodyIn : TopLevelDeclaration Typed.LocatedExpr -> Typed.LocatedExpr -> TopLevelDeclaration Typed.LocatedExpr
 asBodyIn decl body =
     { decl | body = body }

--- a/src/compiler/Stage/Parse.elm
+++ b/src/compiler/Stage/Parse.elm
@@ -15,14 +15,14 @@ import Parser.Advanced as P
 import Stage.Parse.Parser as Parser
 
 
-parse : Project a -> FilePath -> FileContents -> Result Error (Module Frontend.Expr)
+parse : Project a -> FilePath -> FileContents -> Result Error (Module Frontend.LocatedExpr)
 parse { sourceDirectory } filePath (FileContents fileContents) =
     P.run (Parser.module_ filePath) fileContents
         |> Result.mapError (ParseError << ParseProblem)
         |> Result.andThen (checkModuleNameAndFilePath sourceDirectory filePath)
 
 
-checkModuleNameAndFilePath : FilePath -> FilePath -> Module Frontend.Expr -> Result Error (Module Frontend.Expr)
+checkModuleNameAndFilePath : FilePath -> FilePath -> Module Frontend.LocatedExpr -> Result Error (Module Frontend.LocatedExpr)
 checkModuleNameAndFilePath sourceDirectory filePath ({ name } as parsedModule) =
     let
         expectedName : Result Error ModuleName

--- a/src/compiler/Stage/Parse/Parser.elm
+++ b/src/compiler/Stage/Parse/Parser.elm
@@ -8,7 +8,8 @@ module Stage.Parse.Parser exposing
     )
 
 import AST.Common.Literal exposing (Literal(..))
-import AST.Frontend as Frontend exposing (Expr(..))
+import AST.Common.Located as Located exposing (Located)
+import AST.Frontend as Frontend exposing (Expr(..), LocatedExpr)
 import Common
 import Common.Types
     exposing
@@ -43,10 +44,18 @@ type alias Parser_ a =
 
 
 type alias ExprConfig =
-    PP.Config ParseContext ParseProblem Frontend.Expr
+    PP.Config ParseContext ParseProblem Frontend.LocatedExpr
 
 
-module_ : FilePath -> Parser_ (Module Frontend.Expr)
+located : Parser_ p -> Parser_ (Located p)
+located p =
+    P.succeed Located.parsed
+        |= P.getPosition
+        |= p
+        |= P.getPosition
+
+
+module_ : FilePath -> Parser_ (Module Frontend.LocatedExpr)
 module_ filePath =
     P.succeed
         (\( moduleType_, moduleName_, exposing_ ) dependencies_ topLevelDeclarations_ ->
@@ -299,7 +308,7 @@ reservedWords =
         ]
 
 
-topLevelDeclarations : Parser_ (List (ModuleName -> TopLevelDeclaration Frontend.Expr))
+topLevelDeclarations : Parser_ (List (ModuleName -> TopLevelDeclaration Frontend.LocatedExpr))
 topLevelDeclarations =
     oneOrMoreWith P.spaces
         (P.succeed identity
@@ -308,7 +317,7 @@ topLevelDeclarations =
         )
 
 
-topLevelDeclaration : Parser_ (ModuleName -> TopLevelDeclaration Frontend.Expr)
+topLevelDeclaration : Parser_ (ModuleName -> TopLevelDeclaration Frontend.LocatedExpr)
 topLevelDeclaration =
     P.succeed
         (\name body module__ ->
@@ -324,7 +333,7 @@ topLevelDeclaration =
         |= expr
 
 
-expr : Parser_ Frontend.Expr
+expr : Parser_ Frontend.LocatedExpr
 expr =
     PP.expression
         { oneOf =
@@ -341,13 +350,15 @@ expr =
             -- TODO test this: does `x =\n  call 1\n+ something` work? (it shouldn't: no space before '+')
             [ PP.infixLeft 99
                 checkNotBeginningOfLine
-                (\fn argument ->
-                    Frontend.Call
-                        { fn = fn
-                        , argument = argument
-                        }
+                (Located.merge
+                    (\fn argument ->
+                        Frontend.Call
+                            { fn = fn
+                            , argument = argument
+                            }
+                    )
                 )
-            , PP.infixLeft 1 (P.symbol (P.Token "+" ExpectingPlusOperator)) Plus
+            , PP.infixLeft 1 (P.symbol (P.Token "+" ExpectingPlusOperator)) (Located.merge Plus)
             ]
         , spaces = P.spaces
         }
@@ -367,7 +378,7 @@ checkNotBeginningOfLine =
             )
 
 
-parenthesizedExpr : ExprConfig -> Parser_ Frontend.Expr
+parenthesizedExpr : ExprConfig -> Parser_ Frontend.LocatedExpr
 parenthesizedExpr config =
     P.succeed identity
         |. P.symbol (P.Token "(" ExpectingLeftParen)
@@ -375,7 +386,7 @@ parenthesizedExpr config =
         |. P.symbol (P.Token ")" ExpectingRightParen)
 
 
-literal : Parser_ Frontend.Expr
+literal : Parser_ Frontend.LocatedExpr
 literal =
     P.succeed Literal
         |= P.oneOf
@@ -385,6 +396,7 @@ literal =
             , literalBool
             ]
         |> P.inContext InLiteral
+        |> located
 
 
 literalNumber : Parser_ Literal
@@ -570,7 +582,7 @@ literalBool =
             ]
 
 
-var : Parser_ Frontend.Expr
+var : Parser_ Frontend.LocatedExpr
 var =
     P.oneOf
         [ P.map
@@ -578,6 +590,7 @@ var =
             varName
         , qualifiedVar
         ]
+        |> located
 
 
 varName : Parser_ String
@@ -616,7 +629,7 @@ qualifiedVar =
             )
 
 
-lambda : ExprConfig -> Parser_ Frontend.Expr
+lambda : ExprConfig -> Parser_ Frontend.LocatedExpr
 lambda config =
     P.succeed
         (\arguments body ->
@@ -638,7 +651,7 @@ lambda config =
 
                    TODO add a fuzz test for this invariant?
                 -}
-                (Frontend.transform (promoteArguments arguments) body)
+                (Located.map (Frontend.transform (promoteArguments arguments)) body)
         )
         |. P.symbol (P.Token "\\" ExpectingBackslash)
         |= oneOrMoreWith spacesOnly (P.map VarName varName)
@@ -647,9 +660,10 @@ lambda config =
         |. P.spaces
         |= PP.subExpression 0 config
         |> P.inContext InLambda
+        |> located
 
 
-if_ : ExprConfig -> Parser_ Frontend.Expr
+if_ : ExprConfig -> Parser_ Frontend.LocatedExpr
 if_ config =
     P.succeed
         (\test then_ else_ ->
@@ -666,9 +680,10 @@ if_ config =
         |. P.keyword (P.Token "else" ExpectingElse)
         |= PP.subExpression 0 config
         |> P.inContext InIf
+        |> located
 
 
-let_ : ExprConfig -> Parser_ Frontend.Expr
+let_ : ExprConfig -> Parser_ Frontend.LocatedExpr
 let_ config =
     P.succeed
         (\binding_ body ->
@@ -686,9 +701,10 @@ let_ config =
         |. P.spaces
         |= PP.subExpression 0 config
         |> P.inContext InLet
+        |> located
 
 
-binding : ExprConfig -> Parser_ (Binding Frontend.Expr)
+binding : ExprConfig -> Parser_ (Binding Frontend.LocatedExpr)
 binding config =
     P.succeed Binding
         |= P.map VarName varName
@@ -714,14 +730,15 @@ promoteArguments arguments expr_ =
             expr_
 
 
-unit : ExprConfig -> Parser_ Frontend.Expr
+unit : ExprConfig -> Parser_ Frontend.LocatedExpr
 unit _ =
     P.succeed Frontend.Unit
         |. P.keyword (P.Token "()" ExpectingUnit)
         |> P.inContext InUnit
+        |> located
 
 
-list : ExprConfig -> Parser_ Frontend.Expr
+list : ExprConfig -> Parser_ Frontend.LocatedExpr
 list config =
     P.succeed Frontend.List
         |= P.sequence
@@ -733,6 +750,7 @@ list config =
             , trailing = P.Forbidden
             }
         |> P.inContext InList
+        |> located
 
 
 

--- a/src/compiler/Stage/PrepareForBackend.elm
+++ b/src/compiler/Stage/PrepareForBackend.elm
@@ -2,6 +2,7 @@ module Stage.PrepareForBackend exposing (prepareForBackend)
 
 import AST.Backend as Backend
 import AST.Common.Literal exposing (Literal(..))
+import AST.Common.Located as Located
 import AST.Typed as Typed exposing (Expr_(..))
 import Common
 import Common.Types
@@ -38,17 +39,17 @@ prepareForBackend p =
 
 
 type alias Dependency =
-    { from : TopLevelDeclaration Typed.Expr
-    , to : TopLevelDeclaration Typed.Expr
+    { from : TopLevelDeclaration Typed.LocatedExpr
+    , to : TopLevelDeclaration Typed.LocatedExpr
     }
 
 
-modulesToGraph : ModuleName -> Modules Typed.Expr -> Result PrepareForBackendError Backend.Graph
+modulesToGraph : ModuleName -> Modules Typed.LocatedExpr -> Result PrepareForBackendError Backend.Graph
 modulesToGraph mainModuleName modules =
     -- TODO this is probably a bit far off, but... how to allow for cyclic
     -- dependencies in lambdas but not in exposed expressions?
     let
-        maybeMainDeclaration : Maybe (TopLevelDeclaration Typed.Expr)
+        maybeMainDeclaration : Maybe (TopLevelDeclaration Typed.LocatedExpr)
         maybeMainDeclaration =
             Dict.Any.get mainModuleName modules
                 |> Maybe.andThen (.topLevelDeclarations >> Dict.Any.get (VarName "main"))
@@ -65,12 +66,12 @@ modulesToGraph mainModuleName modules =
                             (Set.Any.empty Common.topLevelDeclarationToString)
                             []
 
-                    declarationList : List (TopLevelDeclaration Typed.Expr)
+                    declarationList : List (TopLevelDeclaration Typed.LocatedExpr)
                     declarationList =
                         declarations
                             |> Set.Any.toList
 
-                    declarationIndexes : AnyDict String (TopLevelDeclaration Typed.Expr) Int
+                    declarationIndexes : AnyDict String (TopLevelDeclaration Typed.LocatedExpr) Int
                     declarationIndexes =
                         declarationList
                             |> List.indexedMap (\i declaration -> ( declaration, i ))
@@ -96,11 +97,11 @@ modulesToGraph mainModuleName modules =
 
 
 collectTopLevelDependencies :
-    Modules Typed.Expr
-    -> List (TopLevelDeclaration Typed.Expr)
-    -> AnySet String (TopLevelDeclaration Typed.Expr)
+    Modules Typed.LocatedExpr
+    -> List (TopLevelDeclaration Typed.LocatedExpr)
+    -> AnySet String (TopLevelDeclaration Typed.LocatedExpr)
     -> List Dependency
-    -> ( AnySet String (TopLevelDeclaration Typed.Expr), List Dependency )
+    -> ( AnySet String (TopLevelDeclaration Typed.LocatedExpr), List Dependency )
 collectTopLevelDependencies modules remainingDeclarations doneDeclarations doneDependencies =
     -- TODO maybe keep a dict around so that we don't do the same work twice if
     -- two declarations depend on the same declaration
@@ -139,13 +140,13 @@ collectTopLevelDependencies modules remainingDeclarations doneDeclarations doneD
                     (doneDependencies ++ newDependencies)
 
 
-findDependencies : Modules Typed.Expr -> Typed.Expr -> List (TopLevelDeclaration Typed.Expr)
-findDependencies modules ( expr, _ ) =
+findDependencies : Modules Typed.LocatedExpr -> Typed.LocatedExpr -> List (TopLevelDeclaration Typed.LocatedExpr)
+findDependencies modules located =
     let
         findDependencies_ =
             findDependencies modules
     in
-    case expr of
+    case Typed.getExpr located of
         Literal _ ->
             []
 

--- a/tests/EmitTest.elm
+++ b/tests/EmitTest.elm
@@ -83,7 +83,8 @@ javascript =
                     , ( "positive zero float", Literal (Float 0.0), "0" )
                     , ( "negative zero float", Literal (Float -0.0), "0" )
                     , ( "positive infitiny", Literal (Float (1 / 0.0)), "Infinity" )
-                    , ( "negative infitiny", Literal (Float (1 / -0.0)), "-Infinity" )
+                    , -- Elm wat
+                      ( "negative infitiny", Literal (Float (1 / -0.0)), "-Infinity" )
                     ]
                 )
             , describe "Char"

--- a/tests/EmitTest.elm
+++ b/tests/EmitTest.elm
@@ -81,10 +81,10 @@ javascript =
                     [ ( "positive float", Literal (Float 12.3), "12.3" )
                     , ( "negative float", Literal (Float -12.3), "-12.3" )
                     , ( "positive zero float", Literal (Float 0.0), "0" )
-                    , ( "negative zero float", Literal (Float -0.0), "0" )
-                    , ( "positive infitiny", Literal (Float (1 / 0.0)), "Infinity" )
                     , -- Elm wat
-                      ( "negative infitiny", Literal (Float (1 / -0.0)), "-Infinity" )
+                      ( "negative zero float", Literal (Float -0.0), "0" )
+                    , ( "positive infitiny", Literal (Float (1 / 0.0)), "Infinity" )
+                    , ( "negative infitiny", Literal (Float (1 / -0.0)), "-Infinity" )
                     ]
                 )
             , describe "Char"

--- a/tests/EmitTest.elm
+++ b/tests/EmitTest.elm
@@ -1,8 +1,9 @@
 module EmitTest exposing (javascript)
 
 import AST.Common.Literal exposing (Literal(..))
+import AST.Common.Located as Located exposing (Located)
 import AST.Common.Type as Type
-import AST.Typed as Typed exposing (Expr_(..))
+import AST.Typed as Typed exposing (Expr_(..), LocatedExpr)
 import Common
 import Common.Types
     exposing
@@ -14,6 +15,37 @@ import Dict.Any
 import Expect exposing (Expectation)
 import Stage.Emit.JavaScript as JS
 import Test exposing (Test, describe, test, todo)
+
+
+typedHelp : Typed.Expr -> Typed.LocatedExpr
+typedHelp expr =
+    Located.located
+        -- position do not matters in emit
+        { start = { row = 0, col = 0 }, end = { row = 0, col = 0 } }
+        expr
+
+
+typed : Typed.Expr_ -> Typed.LocatedExpr
+typed expr =
+    Located.located
+        -- position do not matters in emit
+        { start = { row = 0, col = 0 }, end = { row = 0, col = 0 } }
+        ( expr, Type.Int )
+
+
+typedInt : Int -> Typed.LocatedExpr
+typedInt int =
+    typedHelp ( Literal (Int int), Type.Int )
+
+
+typedBool : Bool -> Typed.LocatedExpr
+typedBool bool =
+    typedHelp ( Literal (Bool bool), Type.Bool )
+
+
+typedString : String -> Typed.LocatedExpr
+typedString str =
+    typedHelp ( Literal (String str), Type.String )
 
 
 javascript : Test
@@ -29,30 +61,12 @@ javascript =
                             |> typed
                             |> JS.emitExpr
                             |> Expect.equal output
-
-            typed : Typed.Expr_ -> Typed.Expr
-            typed expr =
-                ( expr, Type.Int )
-
-            typedInt : Int -> Typed.Expr
-            typedInt int =
-                typed (Literal (Int int))
-
-            typedString : String -> Typed.Expr
-            typedString str =
-                typed (Literal (String str))
-
-            typedBool : Bool -> Typed.Expr
-            typedBool bool =
-                typed (Literal (Bool bool))
           in
-          describe "emitExpr"
+          describe "emitExpr_"
             [ describe "Int"
                 (List.map runTest
                     [ ( "positive int", Literal (Int 42), "42" )
                     , ( "negative int", Literal (Int -998), "-998" )
-                    , -- Elm wat
-                      ( "negative zero int", Literal (Int (negate 0)), "0" )
                     ]
                 )
 
@@ -62,8 +76,7 @@ javascript =
                     [ ( "positive float", Literal (Float 12.3), "12.3" )
                     , ( "negative float", Literal (Float -12.3), "-12.3" )
                     , ( "positive zero float", Literal (Float 0.0), "0" )
-                    , -- Elm wat
-                      ( "negative zero float", Literal (Float -0.0), "0" )
+                    , ( "negative zero float", Literal (Float -0.0), "0" )
                     , ( "positive infitiny", Literal (Float (1 / 0.0)), "Infinity" )
                     , ( "negative infitiny", Literal (Float (1 / -0.0)), "-Infinity" )
                     ]
@@ -182,11 +195,11 @@ javascript =
                       , "[]"
                       )
                     , ( "single item in list"
-                      , List [ typed (Literal (Int 1)) ]
+                      , List [ typedInt 1 ]
                       , "[1]"
                       )
                     , ( "simple list"
-                      , List [ typed (Literal (Int 1)), typed (Literal (Int 2)), typed (Literal (Int 3)) ]
+                      , List [ typedInt 1, typedInt 2, typedInt 3 ]
                       , "[1, 2, 3]"
                       )
                     ]
@@ -252,7 +265,7 @@ javascript =
                 )
             ]
         , let
-            runTest : ( String, TopLevelDeclaration Typed.Expr, String ) -> Test
+            runTest : ( String, TopLevelDeclaration Typed.LocatedExpr, String ) -> Test
             runTest ( description, input, output ) =
                 test description <|
                     \() ->
@@ -265,7 +278,7 @@ javascript =
                 [ ( "simple"
                   , { module_ = ModuleName "Foo"
                     , name = VarName "bar"
-                    , body = ( Literal (Int 1), Type.Int )
+                    , body = typedInt 1
                     }
                   , "const Foo$bar = 1;"
                   )

--- a/tests/EmitTest.elm
+++ b/tests/EmitTest.elm
@@ -17,19 +17,22 @@ import Stage.Emit.JavaScript as JS
 import Test exposing (Test, describe, test, todo)
 
 
+dummyPosition : Located.Region
+dummyPosition =
+    { start = { row = 0, col = 0 }, end = { row = 0, col = 0 } }
+
+
 typedHelp : Typed.Expr -> Typed.LocatedExpr
 typedHelp expr =
     Located.located
-        -- position do not matters in emit
-        { start = { row = 0, col = 0 }, end = { row = 0, col = 0 } }
+        dummyPosition
         expr
 
 
 typed : Typed.Expr_ -> Typed.LocatedExpr
 typed expr =
     Located.located
-        -- position do not matters in emit
-        { start = { row = 0, col = 0 }, end = { row = 0, col = 0 } }
+        dummyPosition
         ( expr, Type.Int )
 
 
@@ -62,11 +65,13 @@ javascript =
                             |> JS.emitExpr
                             |> Expect.equal output
           in
-          describe "emitExpr_"
+          describe "emitExpr"
             [ describe "Int"
                 (List.map runTest
                     [ ( "positive int", Literal (Int 42), "42" )
                     , ( "negative int", Literal (Int -998), "-998" )
+                    , -- Elm wat
+                      ( "negative zero int", Literal (Int (negate 0)), "0" )
                     ]
                 )
 

--- a/tests/InferTypesTest.elm
+++ b/tests/InferTypesTest.elm
@@ -1,8 +1,9 @@
 module InferTypesTest exposing (typeInference, typeToString)
 
 import AST.Canonical as Canonical
-import AST.Common.Literal exposing (Literal(..))
-import AST.Common.Type as Type exposing (Type)
+import AST.Common.Literal as Literal
+import AST.Common.Located as Located exposing (located)
+import AST.Common.Type as Type exposing (Type(..))
 import AST.Typed as Typed
 import Common
 import Common.Types as Types
@@ -30,86 +31,46 @@ typeInference =
         (List.map runSection
             [ ( "list"
               , [ ( "empty list"
-                  , Canonical.List []
-                  , Ok ( Typed.List [], Type.List (Type.Var 1) )
+                  , located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Canonical.List [])
+                  , Ok (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } ( Typed.List [], List (Var 1) ))
                   )
                 , ( "one item"
-                  , Canonical.List [ Canonical.Literal (Bool True) ]
-                  , Ok ( Typed.List [ ( Typed.Literal (Bool True), Type.Bool ) ], Type.List Type.Bool )
+                  , located { end = { col = 4, row = 1 }, start = { col = 1, row = 1 } } (Canonical.List [ located { end = { col = 3, row = 1 }, start = { col = 2, row = 1 } } (Canonical.Literal (Literal.Int 1)) ])
+                  , Ok (located { end = { col = 4, row = 1 }, start = { col = 1, row = 1 } } ( Typed.List [ located { end = { col = 3, row = 1 }, start = { col = 2, row = 1 } } ( Typed.Literal (Literal.Int 1), Int ) ], List Int ))
                   )
                 , ( "more items"
-                  , Canonical.List [ Canonical.Literal (Int 1), Canonical.Literal (Int 2), Canonical.Literal (Int 3) ]
-                  , Ok ( Typed.List [ ( Typed.Literal (Int 1), Type.Int ), ( Typed.Literal (Int 2), Type.Int ), ( Typed.Literal (Int 3), Type.Int ) ], Type.List Type.Int )
+                  , located { end = { col = 8, row = 1 }, start = { col = 1, row = 1 } } (Canonical.List [ located { end = { col = 3, row = 1 }, start = { col = 2, row = 1 } } (Canonical.Literal (Literal.Int 1)), located { end = { col = 5, row = 1 }, start = { col = 4, row = 1 } } (Canonical.Literal (Literal.Int 2)), located { end = { col = 7, row = 1 }, start = { col = 6, row = 1 } } (Canonical.Literal (Literal.Int 3)) ])
+                  , Ok (located { end = { col = 8, row = 1 }, start = { col = 1, row = 1 } } ( Typed.List [ located { end = { col = 3, row = 1 }, start = { col = 2, row = 1 } } ( Typed.Literal (Literal.Int 1), Int ), located { end = { col = 5, row = 1 }, start = { col = 4, row = 1 } } ( Typed.Literal (Literal.Int 2), Int ), located { end = { col = 7, row = 1 }, start = { col = 6, row = 1 } } ( Typed.Literal (Literal.Int 3), Int ) ], List Int ))
                   )
                 , ( "different types"
-                  , Canonical.List [ Canonical.Literal (Int 1), Canonical.Literal (String "two") ]
+                  , located { end = { col = 10, row = 1 }, start = { col = 1, row = 1 } } (Canonical.List [ located { end = { col = 3, row = 1 }, start = { col = 2, row = 1 } } (Canonical.Literal (Literal.Int 1)), located { end = { col = 7, row = 1 }, start = { col = 4, row = 1 } } (Canonical.Literal (Literal.String "2")) ])
                   , Err (Error.TypeMismatch Type.Int Type.String)
                   )
                 , ( "more items with different types"
-                  , Canonical.List [ Canonical.Literal (Bool True), Canonical.Literal (String "two"), Canonical.Literal (Int 3) ]
+                  , located { end = { col = 10, row = 1 }, start = { col = 1, row = 1 } } (Canonical.List [ located { end = { col = 3, row = 1 }, start = { col = 2, row = 1 } } (Canonical.Literal (Literal.Bool True)), located { end = { col = 7, row = 1 }, start = { col = 4, row = 1 } } (Canonical.Literal (Literal.String "two")), located { end = { col = 7, row = 1 }, start = { col = 4, row = 1 } } (Canonical.Literal (Literal.Int 3)) ])
                   , Err (Error.TypeMismatch Type.Bool Type.String)
-                  )
-                , ( "List of List of Int"
-                  , Canonical.List [ Canonical.List [ Canonical.Literal (Int 1) ], Canonical.List [ Canonical.Literal (Int 2) ] ]
-                  , Ok ( Typed.List [ ( Typed.List [ ( Typed.Literal (Int 1), Type.Int ) ], Type.List Type.Int ), ( Typed.List [ ( Typed.Literal (Int 2), Type.Int ) ], Type.List Type.Int ) ], Type.List (Type.List Type.Int) )
-                  )
-                , ( "List of List of different types"
-                  , Canonical.List [ Canonical.List [ Canonical.Literal (Int 1) ], Canonical.List [ Canonical.Literal (Bool False) ] ]
-                  , Err (Error.TypeMismatch Type.Int Type.Bool)
                   )
                 ]
               )
             , ( "tuple"
               , [ ( "items with the same types"
-                  , Canonical.Tuple
-                        (Canonical.Literal (String "Hello"))
-                        (Canonical.Literal (String "Elm"))
-                  , Ok
-                        ( Typed.Tuple
-                            ( Typed.Literal (String "Hello"), Type.String )
-                            ( Typed.Literal (String "Elm"), Type.String )
-                        , Type.Tuple Type.String Type.String
-                        )
+                  , located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Canonical.Tuple (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Canonical.Literal (Literal.String "Hello"))) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Canonical.Literal (Literal.String "Elm"))))
+                  , Ok (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } ( Typed.Tuple (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } ( Typed.Literal (Literal.String "Hello"), String )) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } ( Typed.Literal (Literal.String "Elm"), String )), Tuple String String ))
                   )
                 , ( "items of different types"
-                  , Canonical.Tuple
-                        (Canonical.Literal (Bool True))
-                        (Canonical.Literal (Int 1))
-                  , Ok
-                        ( Typed.Tuple
-                            ( Typed.Literal (Bool True), Type.Bool )
-                            ( Typed.Literal (Int 1), Type.Int )
-                        , Type.Tuple Type.Bool Type.Int
-                        )
+                  , located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Canonical.Tuple (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Canonical.Literal (Literal.Bool True))) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Canonical.Literal (Literal.Int 1))))
+                  , Ok (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } ( Typed.Tuple (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } ( Typed.Literal (Literal.Bool True), Bool )) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } ( Typed.Literal (Literal.Int 1), Int )), Tuple Bool Int ))
                   )
                 ]
               )
             , ( "tuple3"
               , [ ( "same types"
-                  , Canonical.Tuple3
-                        (Canonical.Literal (String "FP"))
-                        (Canonical.Literal (String "is"))
-                        (Canonical.Literal (String "good"))
-                  , Ok
-                        ( Typed.Tuple3
-                            ( Typed.Literal (String "FP"), Type.String )
-                            ( Typed.Literal (String "is"), Type.String )
-                            ( Typed.Literal (String "good"), Type.String )
-                        , Type.Tuple3 Type.String Type.String Type.String
-                        )
+                  , located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Canonical.Tuple3 (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Canonical.Literal (Literal.String "FP"))) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Canonical.Literal (Literal.String "is"))) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Canonical.Literal (Literal.String "good"))))
+                  , Ok (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } ( Typed.Tuple3 (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } ( Typed.Literal (Literal.String "FP"), String )) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } ( Typed.Literal (Literal.String "is"), String )) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } ( Typed.Literal (Literal.String "good"), String )), Tuple3 String String String ))
                   )
                 , ( "different types"
-                  , Canonical.Tuple3
-                        (Canonical.Literal (Bool True))
-                        (Canonical.Literal (Int 1))
-                        (Canonical.Literal (Char 'h'))
-                  , Ok
-                        ( Typed.Tuple3
-                            ( Typed.Literal (Bool True), Type.Bool )
-                            ( Typed.Literal (Int 1), Type.Int )
-                            ( Typed.Literal (Char 'h'), Type.Char )
-                        , Type.Tuple3 Type.Bool Type.Int Type.Char
-                        )
+                  , located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Canonical.Tuple3 (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Canonical.Literal (Literal.Bool True))) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Canonical.Literal (Literal.Int 1))) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Canonical.Literal (Literal.Char 'h'))))
+                  , Ok (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } ( Typed.Tuple3 (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } ( Typed.Literal (Literal.Bool True), Bool )) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } ( Typed.Literal (Literal.Int 1), Int )) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } ( Typed.Literal (Literal.Char 'h'), Char )), Tuple3 Bool Int Char ))
                   )
                 ]
               )

--- a/tests/InferTypesTest.elm
+++ b/tests/InferTypesTest.elm
@@ -1,7 +1,6 @@
 module InferTypesTest exposing (typeInference, typeToString)
 
 import AST.Canonical as Canonical
-import AST.Typed as Typed
 import AST.Common.Literal as Literal
 import AST.Common.Located as Located
 import AST.Common.Type as Type exposing (Type(..))
@@ -26,28 +25,27 @@ typeInference =
             test description <|
                 \() ->
                     located input
-                      |> Stage.InferTypes.inferExpr
-                      |> Result.map Typed.getType
-                      |> Expect.equal output
+                        |> Stage.InferTypes.inferExpr
+                        |> Result.map Typed.getType
+                        |> Expect.equal output
 
         located =
             Located.located { start = { row = 0, col = 0 }, end = { row = 0, col = 0 } }
-
     in
     describe "Stage.InferType"
         (List.map runSection
             [ ( "list"
               , [ ( "empty list"
                   , Canonical.List []
-                  , Ok ( List (Var 1) )
+                  , Ok (List (Var 1))
                   )
                 , ( "one item"
                   , Canonical.List [ located (Canonical.Literal (Literal.Int 1)) ]
-                  , Ok ( List Int )
+                  , Ok (List Int)
                   )
                 , ( "more items"
                   , Canonical.List [ located (Canonical.Literal (Literal.Int 1)), located (Canonical.Literal (Literal.Int 2)), located (Canonical.Literal (Literal.Int 3)) ]
-                  , Ok ( List Int )
+                  , Ok (List Int)
                   )
                 , ( "different types"
                   , Canonical.List [ located (Canonical.Literal (Literal.Int 1)), located (Canonical.Literal (Literal.String "2")) ]
@@ -62,22 +60,22 @@ typeInference =
             , ( "tuple"
               , [ ( "items with the same types"
                   , Canonical.Tuple (located (Canonical.Literal (Literal.String "Hello"))) (located (Canonical.Literal (Literal.String "Elm")))
-                  , Ok ( Tuple String String )
+                  , Ok (Tuple String String)
                   )
                 , ( "items of different types"
                   , Canonical.Tuple (located (Canonical.Literal (Literal.Bool True))) (located (Canonical.Literal (Literal.Int 1)))
-                  , Ok ( Tuple Bool Int )
+                  , Ok (Tuple Bool Int)
                   )
                 ]
               )
             , ( "tuple3"
               , [ ( "same types"
                   , Canonical.Tuple3 (located (Canonical.Literal (Literal.String "FP"))) (located (Canonical.Literal (Literal.String "is"))) (located (Canonical.Literal (Literal.String "good")))
-                  , Ok ( Tuple3 String String String )
+                  , Ok (Tuple3 String String String)
                   )
                 , ( "different types"
                   , Canonical.Tuple3 (located (Canonical.Literal (Literal.Bool True))) (located (Canonical.Literal (Literal.Int 1))) (located (Canonical.Literal (Literal.Char 'h')))
-                  , Ok ( Tuple3 Bool Int Char )
+                  , Ok (Tuple3 Bool Int Char)
                   )
                 ]
               )

--- a/tests/ParserTest.elm
+++ b/tests/ParserTest.elm
@@ -7,7 +7,8 @@ module ParserTest exposing
     )
 
 import AST.Common.Literal exposing (Literal(..))
-import AST.Frontend exposing (Expr(..))
+import AST.Common.Located as Located exposing (Located, located)
+import AST.Frontend exposing (Expr(..), LocatedExpr)
 import Common
 import Common.Types
     exposing
@@ -439,160 +440,110 @@ expr =
             [ ( "lambda"
               , [ ( "works with single argument"
                   , "\\x -> x + 1"
-                  , Just
-                        (AST.Frontend.lambda
-                            [ VarName "x" ]
-                            (Plus
-                                (Argument (VarName "x"))
-                                (Literal (Int 1))
-                            )
-                        )
+                  , Just (located { end = { col = 12, row = 1 }, start = { col = 1, row = 1 } } (Lambda { arguments = [ VarName "x" ], body = located { end = { col = 12, row = 1 }, start = { col = 7, row = 1 } } (Plus (located { end = { col = 8, row = 1 }, start = { col = 7, row = 1 } } (Argument (VarName "x"))) (located { end = { col = 12, row = 1 }, start = { col = 11, row = 1 } } (Literal (Int 1)))) }))
                   )
                 , ( "works with multiple arguments"
                   , "\\x y -> x + y"
-                  , Just
-                        (AST.Frontend.lambda
-                            [ VarName "x", VarName "y" ]
-                            (Plus
-                                (Argument (VarName "x"))
-                                (Argument (VarName "y"))
-                            )
-                        )
+                  , Just (located { end = { col = 14, row = 1 }, start = { col = 1, row = 1 } } (Lambda { arguments = [ VarName "x", VarName "y" ], body = located { end = { col = 14, row = 1 }, start = { col = 9, row = 1 } } (Plus (located { end = { col = 10, row = 1 }, start = { col = 9, row = 1 } } (Argument (VarName "x"))) (located { end = { col = 14, row = 1 }, start = { col = 13, row = 1 } } (Argument (VarName "y")))) }))
                   )
                 ]
               )
             , ( "call"
               , [ ( "simple"
                   , "fn 1"
-                  , Just
-                        (Call
-                            { fn = AST.Frontend.var Nothing (VarName "fn")
-                            , argument = Literal (Int 1)
-                            }
-                        )
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Call { argument = located { end = { col = 5, row = 1 }, start = { col = 4, row = 1 } } (Literal (Int 1)), fn = located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Var { name = VarName "fn", qualifier = Nothing }) }))
                   )
                 , ( "with var"
                   , "fn arg"
-                  , Just
-                        (Call
-                            { fn = AST.Frontend.var Nothing (VarName "fn")
-                            , argument = AST.Frontend.var Nothing (VarName "arg")
-                            }
-                        )
+                  , Just (located { end = { col = 7, row = 1 }, start = { col = 1, row = 1 } } (Call { argument = located { end = { col = 7, row = 1 }, start = { col = 4, row = 1 } } (Var { name = VarName "arg", qualifier = Nothing }), fn = located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Var { name = VarName "fn", qualifier = Nothing }) }))
                   )
                 , ( "multiple"
                   , "fn arg1 arg2"
-                  , Just
-                        (Call
-                            { fn =
-                                Call
-                                    { fn = AST.Frontend.var Nothing (VarName "fn")
-                                    , argument = AST.Frontend.var Nothing (VarName "arg1")
-                                    }
-                            , argument = AST.Frontend.var Nothing (VarName "arg2")
-                            }
-                        )
+                  , Just (located { end = { col = 13, row = 1 }, start = { col = 1, row = 1 } } (Call { argument = located { end = { col = 13, row = 1 }, start = { col = 9, row = 1 } } (Var { name = VarName "arg2", qualifier = Nothing }), fn = located { end = { col = 8, row = 1 }, start = { col = 1, row = 1 } } (Call { argument = located { end = { col = 8, row = 1 }, start = { col = 4, row = 1 } } (Var { name = VarName "arg1", qualifier = Nothing }), fn = located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Var { name = VarName "fn", qualifier = Nothing }) }) }))
                   )
                 , ( "space not needed if parenthesized arg"
                   , "fn(arg1)"
-                  , Just
-                        (Call
-                            { fn = AST.Frontend.var Nothing (VarName "fn")
-                            , argument = AST.Frontend.var Nothing (VarName "arg1")
-                            }
-                        )
+                  , Just (located { end = { col = 8, row = 1 }, start = { col = 1, row = 1 } } (Call { argument = located { end = { col = 8, row = 1 }, start = { col = 4, row = 1 } } (Var { name = VarName "arg1", qualifier = Nothing }), fn = located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Var { name = VarName "fn", qualifier = Nothing }) }))
                   )
                 ]
               )
             , ( "if"
               , [ ( "with one space"
                   , "if 1 then 2 else 3"
-                  , Just
-                        (AST.Frontend.If
-                            { test = Literal (Int 1)
-                            , then_ = Literal (Int 2)
-                            , else_ = Literal (Int 3)
-                            }
-                        )
+                  , Just (located { end = { col = 19, row = 1 }, start = { col = 1, row = 1 } } (If { else_ = located { end = { col = 19, row = 1 }, start = { col = 18, row = 1 } } (Literal (Int 3)), test = located { end = { col = 5, row = 1 }, start = { col = 4, row = 1 } } (Literal (Int 1)), then_ = located { end = { col = 12, row = 1 }, start = { col = 11, row = 1 } } (Literal (Int 2)) }))
                   )
                 , ( "with multiple spaces"
                   , "if   1   then   2   else   3"
-                  , Just
-                        (AST.Frontend.If
-                            { test = Literal (Int 1)
-                            , then_ = Literal (Int 2)
-                            , else_ = Literal (Int 3)
-                            }
-                        )
+                  , Just (located { end = { col = 29, row = 1 }, start = { col = 1, row = 1 } } (If { else_ = located { end = { col = 29, row = 1 }, start = { col = 28, row = 1 } } (Literal (Int 3)), test = located { end = { col = 7, row = 1 }, start = { col = 6, row = 1 } } (Literal (Int 1)), then_ = located { end = { col = 18, row = 1 }, start = { col = 17, row = 1 } } (Literal (Int 2)) }))
                   )
                 ]
               )
             , ( "literal int"
               , [ ( "positive"
                   , "123"
-                  , Just (Literal (Int 123))
+                  , Just (located { end = { col = 4, row = 1 }, start = { col = 1, row = 1 } } (Literal (Int 123)))
                   )
                 , ( "zero"
                   , "0"
-                  , Just (Literal (Int 0))
+                  , Just (located { end = { col = 2, row = 1 }, start = { col = 1, row = 1 } } (Literal (Int 0)))
                   )
                 , ( "hexadecimal int"
                   , "0x123abc"
-                  , Just (Literal (Int 1194684))
+                  , Just (located { end = { col = 9, row = 1 }, start = { col = 1, row = 1 } } (Literal (Int 1194684)))
                   )
                 , ( "hexadecimal int - uppercase"
                   , "0x789DEF"
-                  , Just (Literal (Int 7904751))
+                  , Just (located { end = { col = 9, row = 1 }, start = { col = 1, row = 1 } } (Literal (Int 7904751)))
                   )
                 , ( "negative int"
                   , "-42"
-                  , Just (Literal (Int -42))
+                  , Just (located { end = { col = 4, row = 1 }, start = { col = 1, row = 1 } } (Literal (Int -42)))
                   )
                 , ( "negative hexadecimal"
                   , "-0x123abc"
-                  , Just (Literal (Int -1194684))
+                  , Just (located { end = { col = 10, row = 1 }, start = { col = 1, row = 1 } } (Literal (Int -1194684)))
                   )
                 ]
               )
             , ( "literal float"
               , [ ( "positive"
                   , "12.3"
-                  , Just (Literal (Float 12.3))
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Literal (Float 12.3)))
                   )
                 , ( "zero"
                   , "0.0"
-                  , Just (Literal (Float 0.0))
+                  , Just (located { end = { col = 4, row = 1 }, start = { col = 1, row = 1 } } (Literal (Float 0)))
                   )
                 , ( "negative float"
                   , "-4.2"
-                  , Just (Literal (Float -4.2))
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Literal (Float -4.2)))
                   )
                 , ( "Scientific notation"
                   , "5.12e2"
-                  , Just (Literal (Float 512))
+                  , Just (located { end = { col = 7, row = 1 }, start = { col = 1, row = 1 } } (Literal (Float 512)))
                   )
                 , ( "Uppercase scientific notation"
                   , "5.12E2"
-                  , Just (Literal (Float 512))
+                  , Just (located { end = { col = 7, row = 1 }, start = { col = 1, row = 1 } } (Literal (Float 512)))
                   )
                 , ( "Negative scientific notation"
                   , "-5.12e2"
-                  , Just (Literal (Float -512))
+                  , Just (located { end = { col = 8, row = 1 }, start = { col = 1, row = 1 } } (Literal (Float -512)))
                   )
                 , ( "Negative exponent"
                   , "5e-2"
-                  , Just (Literal (Float 0.05))
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Literal (Float 0.05)))
                   )
                 ]
               )
             , ( "literal char"
               , [ ( "number"
                   , "'1'"
-                  , Just (Literal (Char '1'))
+                  , Just (located { end = { col = 4, row = 1 }, start = { col = 1, row = 1 } } (Literal (Char '1')))
                   )
                 , ( "space"
                   , "' '"
-                  , Just (Literal (Char ' '))
+                  , Just (located { end = { col = 4, row = 1 }, start = { col = 1, row = 1 } } (Literal (Char ' ')))
                   )
                 , ( "newline shouldn't work"
                   , "'\n'"
@@ -600,57 +551,57 @@ expr =
                   )
                 , ( "letter lowercase"
                   , "'a'"
-                  , Just (Literal (Char 'a'))
+                  , Just (located { end = { col = 4, row = 1 }, start = { col = 1, row = 1 } } (Literal (Char 'a')))
                   )
                 , ( "letter uppercase"
                   , "'A'"
-                  , Just (Literal (Char 'A'))
+                  , Just (located { end = { col = 4, row = 1 }, start = { col = 1, row = 1 } } (Literal (Char 'A')))
                   )
 
                 -- https://github.com/elm/compiler/blob/dcbe51fa22879f83b5d94642e117440cb5249bb1/compiler/src/Parse/String.hs#L279-L285
                 , ( "escape backslash"
                   , singleQuote "\\\\"
-                  , Just (Literal (Char '\\'))
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Literal (Char '\\')))
                   )
                 , ( "escape n"
                   , singleQuote "\\n"
-                  , Just (Literal (Char '\n'))
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Literal (Char '\n')))
                   )
                 , ( "escape r"
                   , singleQuote "\\r"
-                  , Just (Literal (Char '\u{000D}'))
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Literal (Char '\u{000D}')))
                   )
                 , ( "escape t"
                   , singleQuote "\\t"
-                  , Just (Literal (Char '\t'))
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Literal (Char '\t')))
                   )
                 , ( "double quote"
                   , singleQuote "\""
-                  , Just (Literal (Char '"'))
+                  , Just (located { end = { col = 4, row = 1 }, start = { col = 1, row = 1 } } (Literal (Char '"')))
                     -- " (for vscode-elm bug)
                   )
                 , ( "single quote"
                   , singleQuote "\\'"
-                  , Just (Literal (Char '\''))
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Literal (Char '\'')))
                   )
                 , ( "emoji"
                   , singleQuote "😃"
-                  , Just (Literal (Char '😃'))
+                  , Just (located { end = { col = 4, row = 1 }, start = { col = 1, row = 1 } } (Literal (Char '😃')))
                   )
                 , ( "escaped unicode code point"
                   , singleQuote "\\u{1F648}"
-                  , Just (Literal (Char '🙈'))
+                  , Just (located { end = { col = 12, row = 1 }, start = { col = 1, row = 1 } } (Literal (Char '🙈')))
                   )
                 ]
               )
             , ( "literal string"
               , [ ( "empty"
                   , doubleQuote ""
-                  , Just (Literal (String ""))
+                  , Just (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "")))
                   )
                 , ( "one space"
                   , doubleQuote " "
-                  , Just (Literal (String " "))
+                  , Just (located { end = { col = 4, row = 1 }, start = { col = 1, row = 1 } } (Literal (String " ")))
                   )
                 , ( "newline shouldn't work"
                   , doubleQuote "\n"
@@ -658,189 +609,178 @@ expr =
                   )
                 , ( "two numbers"
                   , doubleQuote "42"
-                  , Just (Literal (String "42"))
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "42")))
                   )
                 , ( "single quote"
                   , doubleQuote "'"
-                  , Just (Literal (String "'"))
+                  , Just (located { end = { col = 4, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "'")))
                   )
                 , ( "double quote"
                   , doubleQuote "\\\""
-                  , Just (Literal (String "\""))
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "\"")))
                   )
                 , ( "escape backslash"
                   , doubleQuote "\\\\"
-                  , Just (Literal (String "\\"))
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "\\")))
                   )
                 , ( "escape n"
                   , doubleQuote "\\n"
-                  , Just (Literal (String "\n"))
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "\n")))
                   )
                 , ( "escape r"
                   , doubleQuote "\\r"
-                  , Just (Literal (String "\u{000D}"))
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "\u{000D}")))
                   )
                 , ( "escape t"
                   , doubleQuote "\\t"
-                  , Just (Literal (String "\t"))
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "\t")))
                   )
                 , ( "emoji"
                   , doubleQuote "😃"
-                  , Just (Literal (String "😃"))
+                  , Just (located { end = { col = 4, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "😃")))
                   )
                 , ( "escaped unicode code point"
                   , doubleQuote "\\u{1F648}"
-                  , Just (Literal (String "🙈"))
+                  , Just (located { end = { col = 12, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "🙈")))
                   )
                 , ( "combo of escapes and chars"
                   , doubleQuote "\\u{1F648}\\n\\r\\t\\\\abc123"
-                  , Just (Literal (String "🙈\n\u{000D}\t\\abc123"))
+                  , Just (located { end = { col = 26, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "🙈\n\u{000D}\t\\abc123")))
                   )
                 ]
               )
             , ( "literal multiline string"
               , [ ( "empty"
                   , tripleQuote ""
-                  , Just (Literal (String ""))
+                  , Just (located { end = { col = 7, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "")))
                   )
                 , ( "one space"
                   , tripleQuote " "
-                  , Just (Literal (String " "))
+                  , Just (located { end = { col = 8, row = 1 }, start = { col = 1, row = 1 } } (Literal (String " ")))
                   )
                 , ( "newline"
                   , tripleQuote "\n"
-                  , Just (Literal (String "\n"))
+                  , Just (located { end = { col = 4, row = 2 }, start = { col = 1, row = 1 } } (Literal (String "\n")))
                   )
                 , ( "two numbers"
                   , tripleQuote "42"
-                  , Just (Literal (String "42"))
+                  , Just (located { end = { col = 9, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "42")))
                   )
                 , ( "single quote"
                   , tripleQuote "'"
-                  , Just (Literal (String "'"))
+                  , Just (located { end = { col = 8, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "'")))
                   )
                 , ( "double quote"
                   , tripleQuote " \" "
-                  , Just (Literal (String " \" "))
+                  , Just (located { end = { col = 10, row = 1 }, start = { col = 1, row = 1 } } (Literal (String " \" ")))
                   )
                 , ( "escape backslash"
                   , tripleQuote "\\\\"
-                  , Just (Literal (String "\\"))
+                  , Just (located { end = { col = 9, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "\\")))
                   )
                 , ( "escape n"
                   , tripleQuote "\\n"
-                  , Just (Literal (String "\n"))
+                  , Just (located { end = { col = 9, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "\n")))
                   )
                 , ( "escape r"
                   , tripleQuote "\\r"
-                  , Just (Literal (String "\u{000D}"))
+                  , Just (located { end = { col = 9, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "\u{000D}")))
                   )
                 , ( "escape t"
                   , tripleQuote "\\t"
-                  , Just (Literal (String "\t"))
+                  , Just (located { end = { col = 9, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "\t")))
                   )
                 , ( "emoji"
                   , tripleQuote "😃"
-                  , Just (Literal (String "😃"))
+                  , Just (located { end = { col = 8, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "😃")))
                   )
                 , ( "escaped unicode code point"
                   , tripleQuote "\\u{1F648}"
-                  , Just (Literal (String "🙈"))
+                  , Just (located { end = { col = 16, row = 1 }, start = { col = 1, row = 1 } } (Literal (String "🙈")))
                   )
                 , ( "combo of escapes, newlines, and chars"
                   , tripleQuote "\\u{1F648}\\n\n\n\\r\\t\\\\abc123"
-                  , Just (Literal (String """🙈
-
-
-\u{000D}\t\\abc123"""))
+                  , Just (located { end = { col = 16, row = 3 }, start = { col = 1, row = 1 } } (Literal (String "🙈\n\n\n\u{000D}\t\\abc123")))
                   )
                 ]
               )
             , ( "literal bool"
               , [ ( "True"
                   , "True"
-                  , Just (Literal (Bool True))
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Literal (Bool True)))
                   )
                 , ( "False"
                   , "False"
-                  , Just (Literal (Bool False))
+                  , Just (located { end = { col = 6, row = 1 }, start = { col = 1, row = 1 } } (Literal (Bool False)))
                   )
                 ]
               )
             , ( "let"
               , [ ( "one liner"
                   , "let x = 1 in 2"
-                  , Just
-                        (Let
-                            { bindings = [ { name = VarName "x", body = Literal (Int 1) } ]
-                            , body = Literal (Int 2)
-                            }
-                        )
+                  , Just (located { end = { col = 15, row = 1 }, start = { col = 1, row = 1 } } (Let { bindings = [ { body = located { end = { col = 10, row = 1 }, start = { col = 9, row = 1 } } (Literal (Int 1)), name = VarName "x" } ], body = located { end = { col = 15, row = 1 }, start = { col = 14, row = 1 } } (Literal (Int 2)) }))
                   )
                 , ( "one binding, generous whitespace"
                   , "let\n  x =\n      1\nin\n  2"
-                  , Just
-                        (Let
-                            { bindings = [ { name = VarName "x", body = Literal (Int 1) } ]
-                            , body = Literal (Int 2)
-                            }
-                        )
+                  , Just (located { end = { col = 4, row = 5 }, start = { col = 1, row = 1 } } (Let { bindings = [ { body = located { end = { col = 8, row = 3 }, start = { col = 7, row = 3 } } (Literal (Int 1)), name = VarName "x" } ], body = located { end = { col = 4, row = 5 }, start = { col = 3, row = 5 } } (Literal (Int 2)) }))
                   )
                 ]
               )
             , ( "list"
               , [ ( "empty list"
                   , "[]"
-                  , Just (List [])
+                  , Just (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (List []))
                   )
                 , ( "empty list with inner spaces"
                   , "[  ]"
-                  , Just (List [])
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (List []))
                   )
                 , ( "single item in list"
                   , "[1]"
-                  , Just (List [ Literal (Int 1) ])
+                  , Just (located { end = { col = 4, row = 1 }, start = { col = 1, row = 1 } } (List [ located { end = { col = 3, row = 1 }, start = { col = 2, row = 1 } } (Literal (Int 1)) ]))
                   )
                 , ( "single item in list with inner spaces"
                   , "[ 1 ]"
-                  , Just (List [ Literal (Int 1) ])
+                  , Just (located { end = { col = 6, row = 1 }, start = { col = 1, row = 1 } } (List [ located { end = { col = 4, row = 1 }, start = { col = 3, row = 1 } } (Literal (Int 1)) ]))
                   )
                 , ( "simple list"
                   , "[1,2,3]"
-                  , Just (List [ Literal (Int 1), Literal (Int 2), Literal (Int 3) ])
+                  , Just (located { end = { col = 8, row = 1 }, start = { col = 1, row = 1 } } (List [ located { end = { col = 3, row = 1 }, start = { col = 2, row = 1 } } (Literal (Int 1)), located { end = { col = 5, row = 1 }, start = { col = 4, row = 1 } } (Literal (Int 2)), located { end = { col = 7, row = 1 }, start = { col = 6, row = 1 } } (Literal (Int 3)) ]))
                   )
                 , ( "simple list with inner spaces"
                   , "[ 1,  2  , 3 ]"
-                  , Just (List [ Literal (Int 1), Literal (Int 2), Literal (Int 3) ])
+                  , Just (located { end = { col = 15, row = 1 }, start = { col = 1, row = 1 } } (List [ located { end = { col = 4, row = 1 }, start = { col = 3, row = 1 } } (Literal (Int 1)), located { end = { col = 8, row = 1 }, start = { col = 7, row = 1 } } (Literal (Int 2)), located { end = { col = 13, row = 1 }, start = { col = 12, row = 1 } } (Literal (Int 3)) ]))
                   )
                 ]
               )
             , ( "unit"
               , [ ( "simple case"
                   , "()"
-                  , Just Unit
+                  , Just (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } Unit)
                   )
                 ]
               )
             , ( "tuple"
               , [ ( "without spaces"
                   , "(1,1)"
-                  , Just (Tuple (Literal (Int 1)) (Literal (Int 1)))
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Tuple (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Literal (Int 1))) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Literal (Int 1)))))
                   )
                 , ( "with inner spaces"
                   , "( 1 , 1 )"
-                  , Just (Tuple (Literal (Int 1)) (Literal (Int 1)))
+                  , Just (located { end = { col = 5, row = 1 }, start = { col = 1, row = 1 } } (Tuple (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Literal (Int 1))) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Literal (Int 1)))))
                   )
                 ]
               )
             , ( "tuple3"
               , [ ( "without spaces"
                   , "(1,2,3)"
-                  , Just (Tuple3 (Literal (Int 1)) (Literal (Int 2)) (Literal (Int 2)))
+                    -- Todo: await parser to ensure located is correct
+                  , Just (located { end = { col = 7, row = 1 }, start = { col = 1, row = 1 } } (Tuple3 (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Literal (Int 1))) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Literal (Int 2))) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Literal (Int 2)))))
                   )
                 , ( "with inner spaces"
                   , "( 1 , 2 , 3 )"
-                  , Just (Tuple3 (Literal (Int 1)) (Literal (Int 2)) (Literal (Int 2)))
+                    -- Todo: await parser to ensure located is correct
+                  , Just (located { end = { col = 7, row = 1 }, start = { col = 1, row = 1 } } (Tuple3 (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Literal (Int 1))) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Literal (Int 2))) (located { end = { col = 3, row = 1 }, start = { col = 1, row = 1 } } (Literal (Int 2)))))
                   )
                 ]
               )


### PR DESCRIPTION
The general assignment is adapting the AST (each stage) to support the following:
```elm
type Located expr
    = Located Region expr

type alias Region =
    { start : Position
    , end : Position
    }

type alias Position =
    { row : Int
    , col : Int
    }

located : Parser_ p -> Parser_ (Located p)
located p =
    P.succeed
        (\( row1, col1 ) expr_ ( row2, col2 ) ->
            Located.located
                { start = { row = row1, col = col1 }
                , end = { row = row2, col = col2 }
                }
                expr_
        )
        |= P.getPosition
        |= p
        |= P.getPosition
```

The objective, is to track position to display them into error messages.

- [x] Add Located Api
- [x] Support Located in Parser
- [x] Refactor Stages(..)
- [x] Refactor Tests
    - test now look a bit cryptic, thanks to the Located leaking everywhere
- [ ] Actually show the position (and maybe even the lines around in the code?)
