### PR TITLE
Support for cons (::) operator

### DIFF
--- a/example-project/src/Main.elm
+++ b/example-project/src/Main.elm
@@ -2,4 +2,4 @@ module Main exposing (main)
 
 
 main =
-    [ 1, 2, 3 ]
+    (1 :: 2) :: [ 3, 4 ]

--- a/src/cli/Main.elm
+++ b/src/cli/Main.elm
@@ -328,6 +328,7 @@ compile project =
                             |> List.map
                                 (\decl ->
                                     decl.body
+                                        |> Frontend.unwrap
                                         |> Debug.log
                                             (Common.moduleNameToString decl.module_
                                                 ++ "."

--- a/src/compiler/AST/Canonical.elm
+++ b/src/compiler/AST/Canonical.elm
@@ -41,6 +41,7 @@ type Expr
     | Var { qualifier : ModuleName, name : VarName }
     | Argument VarName
     | Plus LocatedExpr LocatedExpr
+    | Cons LocatedExpr LocatedExpr
     | Lambda { argument : VarName, body : LocatedExpr }
     | Call { fn : LocatedExpr, argument : LocatedExpr }
     | If { test : LocatedExpr, then_ : LocatedExpr, else_ : LocatedExpr }
@@ -81,6 +82,11 @@ unwrap expr =
 
         Plus e1 e2 ->
             Unwrapped.Plus
+                (unwrap e1)
+                (unwrap e2)
+
+        Cons e1 e2 ->
+            Unwrapped.Cons
                 (unwrap e1)
                 (unwrap e2)
 
@@ -148,6 +154,11 @@ fromUnwrapped expr =
 
             Unwrapped.Plus e1 e2 ->
                 Plus
+                    (fromUnwrapped e1)
+                    (fromUnwrapped e2)
+
+            Unwrapped.Cons e1 e2 ->
+                Cons
                     (fromUnwrapped e1)
                     (fromUnwrapped e2)
 

--- a/src/compiler/AST/Canonical/Unwrapped.elm
+++ b/src/compiler/AST/Canonical/Unwrapped.elm
@@ -18,6 +18,7 @@ type Expr
     | Var { qualifier : ModuleName, name : VarName }
     | Argument VarName
     | Plus Expr Expr
+    | Cons Expr Expr
     | Lambda { argument : VarName, body : Expr }
     | Call { fn : Expr, argument : Expr }
     | If { test : Expr, then_ : Expr, else_ : Expr }

--- a/src/compiler/AST/Frontend.elm
+++ b/src/compiler/AST/Frontend.elm
@@ -85,7 +85,7 @@ recurse f expr =
                 (f_ e1)
                 (f_ e2)
 
-        Cons e1 e2 -> 
+        Cons e1 e2 ->
             Cons
                 (f_ e1)
                 (f_ e2)
@@ -153,12 +153,10 @@ unwrap expr =
                 (unwrap e1)
                 (unwrap e2)
 
-        
         Cons e1 e2 ->
             Unwrapped.Cons
                 (unwrap e1)
                 (unwrap e2)
-
 
         Lambda { arguments, body } ->
             Unwrapped.Lambda

--- a/src/compiler/AST/Frontend.elm
+++ b/src/compiler/AST/Frontend.elm
@@ -35,6 +35,7 @@ type Expr
     | Var { qualifier : Maybe ModuleName, name : VarName }
     | Argument VarName
     | Plus LocatedExpr LocatedExpr
+    | Cons LocatedExpr LocatedExpr
     | Lambda { arguments : List VarName, body : LocatedExpr }
     | Call { fn : LocatedExpr, argument : LocatedExpr }
     | If { test : LocatedExpr, then_ : LocatedExpr, else_ : LocatedExpr }
@@ -81,6 +82,11 @@ recurse f expr =
 
         Plus e1 e2 ->
             Plus
+                (f_ e1)
+                (f_ e2)
+
+        Cons e1 e2 -> 
+            Cons
                 (f_ e1)
                 (f_ e2)
 
@@ -146,6 +152,13 @@ unwrap expr =
             Unwrapped.Plus
                 (unwrap e1)
                 (unwrap e2)
+
+        
+        Cons e1 e2 ->
+            Unwrapped.Cons
+                (unwrap e1)
+                (unwrap e2)
+
 
         Lambda { arguments, body } ->
             Unwrapped.Lambda

--- a/src/compiler/AST/Frontend/Unwrapped.elm
+++ b/src/compiler/AST/Frontend/Unwrapped.elm
@@ -25,3 +25,4 @@ type Expr
     | Unit
     | Tuple Expr Expr
     | Tuple3 Expr Expr Expr
+    | Cons Expr Expr

--- a/src/compiler/AST/Frontend/Unwrapped.elm
+++ b/src/compiler/AST/Frontend/Unwrapped.elm
@@ -17,6 +17,7 @@ type Expr
     | Var { qualifier : Maybe ModuleName, name : VarName }
     | Argument VarName
     | Plus Expr Expr
+    | Cons Expr Expr
     | Lambda { arguments : List VarName, body : Expr }
     | Call { fn : Expr, argument : Expr }
     | If { test : Expr, then_ : Expr, else_ : Expr }
@@ -25,4 +26,3 @@ type Expr
     | Unit
     | Tuple Expr Expr
     | Tuple3 Expr Expr Expr
-    | Cons Expr Expr

--- a/src/compiler/AST/Typed.elm
+++ b/src/compiler/AST/Typed.elm
@@ -8,6 +8,7 @@ module AST.Typed exposing
     , isArgument
     , lambda
     , let_
+    , mapExpr
     , recursiveChildren
     , transformAll
     , transformOnce
@@ -52,6 +53,7 @@ type Expr_
     | Var { qualifier : ModuleName, name : VarName }
     | Argument VarName
     | Plus LocatedExpr LocatedExpr
+    | Cons LocatedExpr LocatedExpr
     | Lambda
         { argument : VarName
         , body : LocatedExpr
@@ -99,6 +101,11 @@ recurse f located =
 
                 Plus e1 e2 ->
                     Plus
+                        (f e1)
+                        (f e2)
+
+                Cons e1 e2 ->
+                    Cons
                         (f e1)
                         (f e2)
 
@@ -178,6 +185,10 @@ recursiveChildren fn located =
             []
 
         Plus left right ->
+            fn left
+                ++ fn right
+
+        Cons left right ->
             fn left
                 ++ fn right
 

--- a/src/compiler/AST/Typed.elm
+++ b/src/compiler/AST/Typed.elm
@@ -12,11 +12,13 @@ module AST.Typed exposing
     , recursiveChildren
     , transformAll
     , transformOnce
+    , unwrap
     )
 
 import AST.Common.Literal exposing (Literal)
 import AST.Common.Located as Located exposing (Located)
 import AST.Common.Type exposing (Type)
+import AST.Typed.Unwrapped as Unwrapped
 import Common
 import Common.Types
     exposing
@@ -234,3 +236,78 @@ getExpr =
 getType : LocatedExpr -> Type
 getType =
     Tuple.second << Located.unwrap
+
+
+unwrap : LocatedExpr -> Unwrapped.Expr
+unwrap expr =
+    let
+        ( expr_, type_ ) =
+            Located.unwrap expr
+    in
+    ( case expr_ of
+        Literal literal ->
+            Unwrapped.Literal literal
+
+        Var var_ ->
+            Unwrapped.Var var_
+
+        Argument name ->
+            Unwrapped.Argument name
+
+        Plus e1 e2 ->
+            Unwrapped.Plus
+                (unwrap e1)
+                (unwrap e2)
+
+        Cons e1 e2 ->
+            Unwrapped.Cons
+                (unwrap e1)
+                (unwrap e2)
+
+        Lambda { argument, body } ->
+            Unwrapped.Lambda
+                { argument = argument
+                , body = unwrap body
+                }
+
+        Call { fn, argument } ->
+            Unwrapped.Call
+                { fn = unwrap fn
+                , argument = unwrap argument
+                }
+
+        If { test, then_, else_ } ->
+            Unwrapped.If
+                { test = unwrap test
+                , then_ = unwrap then_
+                , else_ = unwrap else_
+                }
+
+        Let { bindings, body } ->
+            Unwrapped.Let
+                { bindings =
+                    Dict.Any.map
+                        (always (Common.mapBinding unwrap))
+                        bindings
+                , body = unwrap body
+                }
+
+        List list ->
+            Unwrapped.List
+                (List.map unwrap list)
+
+        Unit ->
+            Unwrapped.Unit
+
+        Tuple e1 e2 ->
+            Unwrapped.Tuple
+                (unwrap e1)
+                (unwrap e2)
+
+        Tuple3 e1 e2 e3 ->
+            Unwrapped.Tuple3
+                (unwrap e1)
+                (unwrap e2)
+                (unwrap e3)
+    , type_
+    )

--- a/src/compiler/AST/Typed/Unwrapped.elm
+++ b/src/compiler/AST/Typed/Unwrapped.elm
@@ -1,0 +1,37 @@
+module AST.Typed.Unwrapped exposing (Expr, Expr_(..))
+
+import AST.Common.Literal exposing (Literal)
+import AST.Common.Type exposing (Type)
+import Common.Types
+    exposing
+        ( Binding
+        , ModuleName
+        , VarName
+        )
+import Dict.Any exposing (AnyDict)
+
+
+{-| This only differs from AST.Typed.Expr by recursing on itself instead of
+on LocatedExpr. Handy for type inference tests!
+-}
+type alias Expr =
+    ( Expr_, Type )
+
+
+type Expr_
+    = Literal Literal
+    | Var { qualifier : ModuleName, name : VarName }
+    | Argument VarName
+    | Plus Expr Expr
+    | Cons Expr Expr
+    | Lambda
+        { argument : VarName
+        , body : Expr
+        }
+    | Call { fn : Expr, argument : Expr }
+    | If { test : Expr, then_ : Expr, else_ : Expr }
+    | Let { bindings : AnyDict String VarName (Binding Expr), body : Expr }
+    | List (List Expr)
+    | Unit
+    | Tuple Expr Expr
+    | Tuple3 Expr Expr Expr

--- a/src/compiler/Error.elm
+++ b/src/compiler/Error.elm
@@ -96,6 +96,7 @@ type ParseProblem
     | ExpectingDoubleQuote
     | ExpectingTripleQuote
     | ExpectingPlusOperator
+    | ExpectingConsOperator
     | ExpectingModuleDot -- `import Foo>.<Bar`
     | ExpectingBackslash -- `>\<x -> x + 1`
     | ExpectingRightArrow -- `\x >->< x + 1`

--- a/src/compiler/Stage/Desugar.elm
+++ b/src/compiler/Stage/Desugar.elm
@@ -92,6 +92,11 @@ desugarExpr modules thisModule located =
                 (recurse e1)
                 (recurse e2)
 
+        Frontend.Cons e1 e2 ->
+            map2 Canonical.Cons
+                (recurse e1)
+                (recurse e2)
+
         Frontend.Lambda { arguments, body } ->
             recurse body
                 |> Result.map (curryLambda located arguments)

--- a/src/compiler/Stage/Emit/JavaScript.elm
+++ b/src/compiler/Stage/Emit/JavaScript.elm
@@ -47,7 +47,7 @@ emitExpr located =
 
         Cons e1 e2 ->
             -- TODO implement emitter for (::)
-            "[].concat([" ++ emitExpr e1 ++ "]," ++ emitExpr e2 ++ ")" 
+            "[].concat([" ++ emitExpr e1 ++ "]," ++ emitExpr e2 ++ ")"
 
         Lambda { argument, body } ->
             -- TODO are these parentheses needed?

--- a/src/compiler/Stage/Emit/JavaScript.elm
+++ b/src/compiler/Stage/Emit/JavaScript.elm
@@ -46,7 +46,7 @@ emitExpr located =
             "(" ++ emitExpr e1 ++ " + " ++ emitExpr e2 ++ ")"
 
         Cons e1 e2 ->
-            "[].concat([" ++ emitExpr e1 ++ "]," ++ emitExpr e2 ++ ")"
+            "[" ++ emitExpr e1 ++ "].concat(" ++ emitExpr e2 ++ ")"
 
         Lambda { argument, body } ->
             -- TODO are these parentheses needed?

--- a/src/compiler/Stage/Emit/JavaScript.elm
+++ b/src/compiler/Stage/Emit/JavaScript.elm
@@ -45,6 +45,10 @@ emitExpr located =
         Plus e1 e2 ->
             "(" ++ emitExpr e1 ++ " + " ++ emitExpr e2 ++ ")"
 
+        Cons e1 e2 ->
+            -- TODO implement emitter for (::)
+            ""
+
         Lambda { argument, body } ->
             -- TODO are these parentheses needed?
             "((" ++ mangleVarName argument ++ ") => " ++ emitExpr body ++ ")"

--- a/src/compiler/Stage/Emit/JavaScript.elm
+++ b/src/compiler/Stage/Emit/JavaScript.elm
@@ -46,7 +46,6 @@ emitExpr located =
             "(" ++ emitExpr e1 ++ " + " ++ emitExpr e2 ++ ")"
 
         Cons e1 e2 ->
-            -- TODO implement emitter for (::)
             "[].concat([" ++ emitExpr e1 ++ "]," ++ emitExpr e2 ++ ")"
 
         Lambda { argument, body } ->

--- a/src/compiler/Stage/Emit/JavaScript.elm
+++ b/src/compiler/Stage/Emit/JavaScript.elm
@@ -47,7 +47,7 @@ emitExpr located =
 
         Cons e1 e2 ->
             -- TODO implement emitter for (::)
-            ""
+            "[].concat([" ++ emitExpr e1 ++ "]," ++ emitExpr e2 ++ ")" 
 
         Lambda { argument, body } ->
             -- TODO are these parentheses needed?

--- a/src/compiler/Stage/InferTypes.elm
+++ b/src/compiler/Stage/InferTypes.elm
@@ -46,6 +46,10 @@ inferExpr located =
 
                    BTW GenerateEquations needed it because in case of some Exprs
                    (like List) it needed to create a new type ID on the fly.
+
+                   TODO those IDs generated on the fly have bad visibility (you
+                   can only infer their existence from the equations, but can't
+                   clearly see what they belong to). Can we do something about it?
                 -}
                 |> Tuple.first
 

--- a/src/compiler/Stage/InferTypes/AssignIds.elm
+++ b/src/compiler/Stage/InferTypes/AssignIds.elm
@@ -97,6 +97,16 @@ assignIdsWithHelp idSource located =
             in
             assignId idSource2 (Typed.Plus e1_ e2_)
 
+        Canonical.Cons e1 e2 ->
+            let
+                ( e1_, idSource1 ) =
+                    assignIdsWith idSource e1
+
+                ( e2_, idSource2 ) =
+                    assignIdsWith idSource1 e2
+            in
+            assignId idSource2 (Typed.Cons e1_ e2_)
+
         Canonical.Lambda { argument, body } ->
             let
                 ( body_, idSource1 ) =

--- a/src/compiler/Stage/InferTypes/GenerateEquations.elm
+++ b/src/compiler/Stage/InferTypes/GenerateEquations.elm
@@ -124,7 +124,7 @@ generateEquations idSource located =
                     generateEquations idSource1 right
             in
             ( -- For expression a :: [ b ]:
-                [ equals rightType (Type.List leftType) -- type of b is a List a
+              [ equals rightType (Type.List leftType) -- type of b is a List a
               , equals type_ rightType -- a :: [ b ] is a List b
               ]
                 ++ leftEquations

--- a/src/compiler/Stage/InferTypes/GenerateEquations.elm
+++ b/src/compiler/Stage/InferTypes/GenerateEquations.elm
@@ -123,7 +123,12 @@ generateEquations idSource located =
                 ( rightEquations, idSource2 ) =
                     generateEquations idSource1 right
             in
-            ( [ equals type_ rightType ] ++ leftEquations ++ rightEquations
+            ( -- For expression a :: [ b ]:
+                [ equals rightType (Type.List leftType) -- type of b is a List a
+              , equals type_ rightType -- a :: [ b ] is a List b
+              ]
+                ++ leftEquations
+                ++ rightEquations
             , idSource2
             )
 

--- a/src/compiler/Stage/InferTypes/GenerateEquations.elm
+++ b/src/compiler/Stage/InferTypes/GenerateEquations.elm
@@ -109,6 +109,12 @@ generateEquations idSource located =
             , idSource2
             )
 
+        -- TODO: implement type inference for (::) operator.
+        Typed.Cons left right ->
+            ( []
+            , idSource
+            )
+
         Typed.Lambda { body, argument } ->
             let
                 ( _, bodyType ) =

--- a/src/compiler/Stage/InferTypes/GenerateEquations.elm
+++ b/src/compiler/Stage/InferTypes/GenerateEquations.elm
@@ -111,8 +111,21 @@ generateEquations idSource located =
 
         -- TODO: implement type inference for (::) operator.
         Typed.Cons left right ->
-            ( []
-            , idSource
+            let
+                ( _, leftType ) =
+                    Located.unwrap left
+
+                ( _, rightType ) =
+                    Located.unwrap right
+
+                ( leftEquations, idSource1 ) =
+                    generateEquations idSource left
+
+                ( rightEquations, idSource2 ) =
+                    generateEquations idSource1 right
+            in
+            ( [ equals type_ rightType ] ++ leftEquations ++ rightEquations
+            , idSource2
             )
 
         Typed.Lambda { body, argument } ->

--- a/src/compiler/Stage/InferTypes/GenerateEquations.elm
+++ b/src/compiler/Stage/InferTypes/GenerateEquations.elm
@@ -109,7 +109,6 @@ generateEquations idSource located =
             , idSource2
             )
 
-        -- TODO: implement type inference for (::) operator.
         Typed.Cons left right ->
             let
                 ( _, leftType ) =

--- a/src/compiler/Stage/InferTypes/Unify.elm
+++ b/src/compiler/Stage/InferTypes/Unify.elm
@@ -8,7 +8,7 @@ import Stage.InferTypes.TypeEquation as TypeEquation exposing (TypeEquation)
 
 {-| TODO document
 -}
-unifyAllEquations : List TypeEquation -> Result TypeError SubstitutionMap
+unifyAllEquations : List TypeEquation -> Result ( TypeError, SubstitutionMap ) SubstitutionMap
 unifyAllEquations equations =
     List.foldl
         (\equation substitutionMap ->
@@ -22,7 +22,7 @@ unifyAllEquations equations =
         equations
 
 
-unify : Type -> Type -> SubstitutionMap -> Result TypeError SubstitutionMap
+unify : Type -> Type -> SubstitutionMap -> Result ( TypeError, SubstitutionMap ) SubstitutionMap
 unify t1 t2 substitutionMap =
     if t1 == t2 then
         Ok substitutionMap
@@ -54,10 +54,10 @@ unify t1 t2 substitutionMap =
                     |> Result.andThen (unify t1e3 t2e3)
 
             _ ->
-                Err (TypeMismatch t1 t2)
+                Err ( TypeMismatch t1 t2, substitutionMap )
 
 
-unifyVariable : Int -> Type -> SubstitutionMap -> Result TypeError SubstitutionMap
+unifyVariable : Int -> Type -> SubstitutionMap -> Result ( TypeError, SubstitutionMap ) SubstitutionMap
 unifyVariable id type_ substitutionMap =
     case SubstitutionMap.get id substitutionMap of
         Just typeForId ->
@@ -74,7 +74,7 @@ unifyVariable id type_ substitutionMap =
 
                 Nothing ->
                     if occurs id type_ substitutionMap then
-                        Err (OccursCheckFailed id type_)
+                        Err ( OccursCheckFailed id type_, substitutionMap )
 
                     else
                         Ok (SubstitutionMap.insert id type_ substitutionMap)

--- a/src/compiler/Stage/Optimize.elm
+++ b/src/compiler/Stage/Optimize.elm
@@ -17,6 +17,7 @@ optimizeExpr : Typed.LocatedExpr -> Typed.LocatedExpr
 optimizeExpr located =
     Typed.transformAll
         [ optimizePlus
+        , optimizeCons
         , optimizeIfLiteralBool
         ]
         located
@@ -38,6 +39,26 @@ optimizePlus located =
                             )
                             located
                         )
+
+                _ ->
+                    Nothing
+
+        _ ->
+            Nothing
+
+
+log : String -> a -> b -> b
+log label data returned =
+    Debug.log label data |> (\_ -> returned)
+
+
+optimizeCons : Typed.LocatedExpr -> Maybe Typed.LocatedExpr
+optimizeCons located =
+    case Typed.getExpr located of
+        Typed.Cons l r ->
+            case Typed.getExpr r of
+                Typed.List list ->
+                    Just (Typed.mapExpr (\_ -> Typed.List (l :: list)) r)
 
                 _ ->
                     Nothing

--- a/src/compiler/Stage/Optimize.elm
+++ b/src/compiler/Stage/Optimize.elm
@@ -47,11 +47,6 @@ optimizePlus located =
             Nothing
 
 
-log : String -> a -> b -> b
-log label data returned =
-    Debug.log label data |> (\_ -> returned)
-
-
 optimizeCons : Typed.LocatedExpr -> Maybe Typed.LocatedExpr
 optimizeCons located =
     case Typed.getExpr located of

--- a/src/compiler/Stage/Optimize.elm
+++ b/src/compiler/Stage/Optimize.elm
@@ -32,13 +32,7 @@ optimizePlus located =
         Typed.Plus l r ->
             case ( Typed.getExpr l, Typed.getExpr r ) of
                 ( Typed.Literal (Literal.Int left), Typed.Literal (Literal.Int right) ) ->
-                    Just
-                        (Located.replaceWith
-                            ( Typed.Literal (Literal.Int (left + right))
-                            , Type.Int
-                            )
-                            located
-                        )
+                    Just (Typed.mapExpr (\_ -> Typed.Literal (Literal.Int (left + right))) r)
 
                 _ ->
                     Nothing

--- a/src/compiler/Stage/Parse/Parser.elm
+++ b/src/compiler/Stage/Parse/Parser.elm
@@ -361,6 +361,7 @@ expr =
                     )
                 )
             , PP.infixLeft 1 (P.symbol (P.Token "+" ExpectingPlusOperator)) (Located.merge Plus)
+            , PP.infixRight 1 (P.symbol (P.Token "::" ExpectingConsOperator)) (Located.merge Cons)
             ]
         , spaces = P.spaces
         }

--- a/src/compiler/Stage/PrepareForBackend.elm
+++ b/src/compiler/Stage/PrepareForBackend.elm
@@ -164,6 +164,10 @@ findDependencies modules located =
             findDependencies_ e1
                 ++ findDependencies_ e2
 
+        Cons e1 e2 ->
+            findDependencies_ e1
+                ++ findDependencies_ e2
+
         Lambda { argument, body } ->
             findDependencies_ body
                 |> List.filter (\decl -> decl.name /= argument)

--- a/tests/EmitTest.elm
+++ b/tests/EmitTest.elm
@@ -101,13 +101,13 @@ javascript =
                 (List.map runTest
                     [ ( "simple"
                       , Cons (typedInt 1) (typedIntList [ 2, 3 ])
-                      , "[].concat([1],[2, 3])"
+                      , "[1].concat([2, 3])"
                       )
                     , ( "nested"
                       , Cons
                             (typedInt 1)
-                            (typed (Cons (typedInt 1) (typedIntList [ 2, 3 ])))
-                      , "[].concat([1],[].concat([1],[2, 3]))"
+                            (typed (Cons (typedInt 2) (typedIntList [ 3, 4 ])))
+                      , "[1].concat([2].concat([3, 4]))"
                       )
                     ]
                 )

--- a/tests/EmitTest.elm
+++ b/tests/EmitTest.elm
@@ -20,6 +20,7 @@ import TestHelpers
         ( typed
         , typedBool
         , typedInt
+        , typedIntList
         , typedString
         )
 
@@ -94,6 +95,12 @@ javascript =
                     -- We need to give the child `Expr`s a type too
                     [ ( "simple", Plus (typedInt 1) (typedInt 2), "(1 + 2)" )
                     , ( "nested", Plus (typedInt 1) (typed (Plus (typedInt 2) (typedInt 3))), "(1 + (2 + 3))" )
+                    ]
+                )
+            , describe "Cons"
+                (List.map runTest
+                    [ ( "simple", Cons (typedInt 1) (typedIntList [ 2, 3 ]), "[].concat([1],[2, 3])" )
+                    , ( "nested", Cons (typedInt 1) (typed (Cons (typedInt 1) (typedIntList [ 2, 3 ]))), "[].concat([1],[].concat([1],[2, 3]))" )
                     ]
                 )
             , describe "Lambda"

--- a/tests/EmitTest.elm
+++ b/tests/EmitTest.elm
@@ -99,8 +99,16 @@ javascript =
                 )
             , describe "Cons"
                 (List.map runTest
-                    [ ( "simple", Cons (typedInt 1) (typedIntList [ 2, 3 ]), "[].concat([1],[2, 3])" )
-                    , ( "nested", Cons (typedInt 1) (typed (Cons (typedInt 1) (typedIntList [ 2, 3 ]))), "[].concat([1],[].concat([1],[2, 3]))" )
+                    [ ( "simple"
+                      , Cons (typedInt 1) (typedIntList [ 2, 3 ])
+                      , "[].concat([1],[2, 3])"
+                      )
+                    , ( "nested"
+                      , Cons
+                            (typedInt 1)
+                            (typed (Cons (typedInt 1) (typedIntList [ 2, 3 ])))
+                      , "[].concat([1],[].concat([1],[2, 3]))"
+                      )
                     ]
                 )
             , describe "Lambda"

--- a/tests/InferTypesTest.elm
+++ b/tests/InferTypesTest.elm
@@ -7,7 +7,7 @@ import AST.Common.Located as Located
 import AST.Common.Type as Type exposing (Type(..))
 import AST.Typed as Typed
 import Common
-import Common.Types as Types exposing (VarName(..))
+import Common.Types as Types exposing (ModuleName(..), VarName(..))
 import Dict.Any
 import Error exposing (TypeError(..))
 import Expect exposing (Expectation)
@@ -111,6 +111,22 @@ typeInference =
                     (CanonicalU.Literal (Literal.Int 1))
                     (CanonicalU.Literal (Literal.Char 'h'))
               , Ok (Tuple3 Bool Int Char)
+              )
+            ]
+        , runSection "plus"
+            [ ( "same types"
+              , CanonicalU.Plus
+                    (CanonicalU.Var { qualifier = ModuleName "Main", name = VarName "age" })
+                    (CanonicalU.Literal (Literal.Int 1))
+              , Ok Int
+              )
+            ]
+        , runSection "cons"
+            [ ( "variable and list"
+              , CanonicalU.Cons
+                    (CanonicalU.Var { qualifier = ModuleName "Main", name = VarName "age" })
+                    (CanonicalU.List [ CanonicalU.Literal (Literal.Int 1) ])
+              , Ok (List Int)
               )
             ]
         ]

--- a/tests/InferTypesTest.elm
+++ b/tests/InferTypesTest.elm
@@ -156,7 +156,7 @@ typeInference =
               , Err
                     (Error.TypeMismatch
                         (Type.List Type.Int)
-                        (Type.List (Type.List Type.Int))
+                        Type.Int
                     )
               )
             , ( "variable and list"

--- a/tests/InferTypesTest.elm
+++ b/tests/InferTypesTest.elm
@@ -122,7 +122,44 @@ typeInference =
               )
             ]
         , runSection "cons"
-            [ ( "variable and list"
+            [ ( "simple case"
+              , CanonicalU.Cons
+                    (CanonicalU.Literal (Literal.Int 1))
+                    (CanonicalU.List [])
+              , Ok (List Int)
+              )
+            , ( "advanced case"
+              , CanonicalU.Cons
+                    (CanonicalU.Literal (Literal.Int 1))
+                    (CanonicalU.Cons
+                        (CanonicalU.Literal (Literal.Int 2))
+                        (CanonicalU.List
+                            [ CanonicalU.Literal (Literal.Int 3)
+                            , CanonicalU.Literal (Literal.Int 4)
+                            ]
+                        )
+                    )
+              , Ok (List Int)
+              )
+            , ( "fail with wrong argument types"
+              , CanonicalU.Cons
+                    (CanonicalU.List
+                        [ CanonicalU.Literal (Literal.Int 1)
+                        , CanonicalU.Literal (Literal.Int 2)
+                        ]
+                    )
+                    (CanonicalU.List
+                        [ CanonicalU.Literal (Literal.Int 3)
+                        , CanonicalU.Literal (Literal.Int 4)
+                        ]
+                    )
+              , Err
+                    (Error.TypeMismatch
+                        (Type.List Type.Int)
+                        (Type.List (Type.List Type.Int))
+                    )
+              )
+            , ( "variable and list"
               , CanonicalU.Cons
                     (CanonicalU.Var { qualifier = ModuleName "Main", name = VarName "age" })
                     (CanonicalU.List [ CanonicalU.Literal (Literal.Int 1) ])

--- a/tests/OptimizeTest.elm
+++ b/tests/OptimizeTest.elm
@@ -20,6 +20,7 @@ import TestHelpers
         ( located
         , typedBool
         , typedInt
+        , typedIntList
         )
 
 
@@ -74,6 +75,19 @@ optimize =
                                 (located ( Argument (VarName "x"), Type.Int ))
                             , Type.Int
                             )
+                      )
+                    ]
+                )
+            , describe "optimizeCons"
+                (List.map runTest
+                    [ ( "works with one value"
+                      , located
+                            ( Cons
+                                (typedInt 1)
+                                (typedIntList [ 2, 3 ])
+                            , Type.Int
+                            )
+                      , typedIntList [ 1, 2, 3 ]
                       )
                     ]
                 )

--- a/tests/ParserTest.elm
+++ b/tests/ParserTest.elm
@@ -932,6 +932,22 @@ expr =
                             )
                         )
                   )
+                , ( "no spaces"
+                  , "1::[]"
+                  , Just
+                        (Cons
+                            (Literal (Int 1))
+                            (List [])
+                        )
+                  )
+                , ( "multiple spaces"
+                  , "1    ::      []"
+                  , Just
+                        (Cons
+                            (Literal (Int 1))
+                            (List [])
+                        )
+                  )
                 ]
               )
             ]

--- a/tests/ParserTest.elm
+++ b/tests/ParserTest.elm
@@ -904,6 +904,28 @@ expr =
                   )
                 ]
               )
+            , ( "cons"
+              , [ ( "simple case"
+                  , "1 :: []"
+                  , Just
+                        (Cons
+                            (Literal (Int 1))
+                            (List [])
+                        )
+                  )
+                , ( "multiple values case"
+                  , "1 :: 2 :: []"
+                  , Just
+                        (Cons
+                            (Literal (Int 1))
+                            (Cons
+                                (Literal (Int 2))
+                                (List [])
+                            )
+                        )
+                  )
+                ]
+              )
             ]
         )
 

--- a/tests/TestHelpers.elm
+++ b/tests/TestHelpers.elm
@@ -4,6 +4,7 @@ module TestHelpers exposing
     , typed
     , typedBool
     , typedInt
+    , typedIntList
     , typedString
     )
 
@@ -59,4 +60,15 @@ typedString str =
     located
         ( Literal (Literal.String str)
         , String
+        )
+
+
+typedIntList : List Int -> Typed.LocatedExpr
+typedIntList list =
+    located
+        ( Typed.List
+            ([ 1, 2, 3 ]
+                |> List.map typedInt
+            )
+        , Type.List Type.Int
         )

--- a/tests/TestHelpers.elm
+++ b/tests/TestHelpers.elm
@@ -66,9 +66,6 @@ typedString str =
 typedIntList : List Int -> Typed.LocatedExpr
 typedIntList list =
     located
-        ( Typed.List
-            (list
-                |> List.map typedInt
-            )
+        ( Typed.List (List.map typedInt list)
         , Type.List Type.Int
         )

--- a/tests/TestHelpers.elm
+++ b/tests/TestHelpers.elm
@@ -67,7 +67,7 @@ typedIntList : List Int -> Typed.LocatedExpr
 typedIntList list =
     located
         ( Typed.List
-            ([ 1, 2, 3 ]
+            (list
                 |> List.map typedInt
             )
         , Type.List Type.Int


### PR DESCRIPTION
Closes #29 

- [x] add parser tests
- [x] add a parser
- [x] add optimization tests
    if the right item (the list) is a literal list (not a variable for example), put the left item into it:
    myStuff :: [1, 2] should become [myStuff, 1, 2]
- [x] add optimization
- [x] ~~change how Lists are emitted: instead of [1,2,3] do something like List$fromJSArray([1,2,3])?~~
- [x] add emit tests - (::) should be just a call of Elm function with those two params
- [x] add emit
- [x] type inference