### PR TITLE
Lib improvements

### DIFF
--- a/cli/Main.elm
+++ b/cli/Main.elm
@@ -44,7 +44,7 @@ import Dict exposing (Dict)
 import Elm.AST.Frontend as Frontend
 import Elm.Compiler.Error as Error exposing (Error(..), ParseError(..))
 import Elm.Compiler.Stage.Desugar as Desugar
-import Elm.Compiler.Stage.Emit.JavaScript as EmitJS
+import Elm.Compiler.Stage.Emit.JS as EmitJS
 import Elm.Compiler.Stage.InferTypes as InferTypes
 import Elm.Compiler.Stage.Optimize as Optimize
 import Elm.Compiler.Stage.Parse as Parse

--- a/cli/Main.elm
+++ b/cli/Main.elm
@@ -43,6 +43,11 @@ about returning those.
 import Dict exposing (Dict)
 import Elm.AST.Frontend as Frontend
 import Elm.Compiler.Error as Error exposing (Error(..), ParseError(..))
+import Elm.Compiler.Stage.Desugar as Desugar
+import Elm.Compiler.Stage.Emit.JavaScript as EmitJS
+import Elm.Compiler.Stage.InferTypes as InferTypes
+import Elm.Compiler.Stage.Optimize as Optimize
+import Elm.Compiler.Stage.Parse as Parse
 import Elm.Data.Declaration as Declaration
 import Elm.Data.FileContents exposing (FileContents)
 import Elm.Data.FilePath as FilePath exposing (FilePath)
@@ -54,11 +59,6 @@ import Json.Decode as JD
 import Platform
 import Ports exposing (println, printlnStderr)
 import Set exposing (Set)
-import Stage.Desugar as Desugar
-import Stage.Emit.JavaScript as EmitJS
-import Stage.InferTypes as InferTypes
-import Stage.Optimize as Optimize
-import Stage.Parse as Parse
 
 
 {-| We're essentially a Node.JS app (until we get self-hosting :P ).

--- a/elm.json
+++ b/elm.json
@@ -8,7 +8,7 @@
         "Elm.Compiler",
         "Elm.Compiler.Error",
         "Elm.Compiler.Stage.Emit",
-        "Elm.Compiler.Stage.Emit.JavaScript",
+        "Elm.Compiler.Stage.Emit.JS",
         "Elm.Data.Binding",
         "Elm.Data.Declaration",
         "Elm.Data.Exposing",

--- a/elm.json
+++ b/elm.json
@@ -7,6 +7,8 @@
     "exposed-modules": [
         "Elm.Compiler",
         "Elm.Compiler.Error",
+        "Elm.Compiler.Stage.Emit",
+        "Elm.Compiler.Stage.Emit.JavaScript",
         "Elm.Data.Binding",
         "Elm.Data.Declaration",
         "Elm.Data.Exposing",

--- a/library-todo.txt
+++ b/library-todo.txt
@@ -1,7 +1,7 @@
 - [ ] Elm.Compiler function type annotations don't really show the transitions between AST modules. (It all looks like LocatedExpr -> LocatedExpr). Try aliasing the types just for the sake of this module.
 - [ ] desugarExpr is needlessly complicated... try creating some dummy throwaway module for that one expr? Does that change behaviour ("can't find variable x")?
-- [ ] Emit helpers
-- [ ] Emit.JavaScript
-- [ ] Elm.Compiler.compileToJS - do the whole pipeline with default settings. Show how it's written in doc comment. Also show it in library README.
 - [ ] maybe show the Ellie demo/playground in library README?
+
+
+- [ ] Elm.Compiler.compileToJS - do the whole pipeline with default settings. Show how it's written in doc comment. Also show it in library README.
 

--- a/library-todo.txt
+++ b/library-todo.txt
@@ -2,4 +2,6 @@
 - [ ] desugarExpr is needlessly complicated... try creating some dummy throwaway module for that one expr? Does that change behaviour ("can't find variable x")?
 - [ ] Emit helpers
 - [ ] Emit.JavaScript
-- [ ] Elm.Compiler.compileToJS - do the whole pipeline with default settings. Show how it's written in doc comment
+- [ ] Elm.Compiler.compileToJS - do the whole pipeline with default settings. Show how it's written in doc comment. Also show it in library README.
+- [ ] maybe show the Ellie demo/playground in library README?
+

--- a/src/Elm/Compiler/Stage/Desugar.elm
+++ b/src/Elm/Compiler/Stage/Desugar.elm
@@ -1,4 +1,4 @@
-module Stage.Desugar exposing (desugar, desugarExpr)
+module Elm.Compiler.Stage.Desugar exposing (desugar, desugarExpr)
 
 import Basics.Extra exposing (flip)
 import Dict exposing (Dict)
@@ -6,6 +6,7 @@ import Dict.Extra as Dict
 import Elm.AST.Canonical as Canonical
 import Elm.AST.Frontend as Frontend
 import Elm.Compiler.Error exposing (DesugarError(..), Error(..))
+import Elm.Compiler.Stage.Desugar.Boilerplate as Boilerplate
 import Elm.Data.Binding as Binding
 import Elm.Data.Located as Located
 import Elm.Data.Module as Module exposing (Module)
@@ -14,7 +15,6 @@ import Elm.Data.Project exposing (Project)
 import Elm.Data.VarName exposing (VarName)
 import Maybe.Extra
 import Result.Extra as Result
-import Stage.Desugar.Boilerplate as Boilerplate
 
 
 desugar : Project Frontend.ProjectFields -> Result Error (Project Canonical.ProjectFields)

--- a/src/Elm/Compiler/Stage/Desugar/Boilerplate.elm
+++ b/src/Elm/Compiler/Stage/Desugar/Boilerplate.elm
@@ -1,4 +1,4 @@
-module Stage.Desugar.Boilerplate exposing
+module Elm.Compiler.Stage.Desugar.Boilerplate exposing
     ( desugarModule
     , desugarProject
     )

--- a/src/Elm/Compiler/Stage/Emit.elm
+++ b/src/Elm/Compiler/Stage/Emit.elm
@@ -22,11 +22,11 @@ There are two emit usecases we know of:
 
 There _might_ be usecases for not eliminating dead code? We don't do that
 currently because we don't know of any, but if there are, please raise an issue
-in the GitHub repo!
-
-TODO we'll probably have to detect cycles and do something like IIFE
+in the [GitHub repo](https://github.com/elm-in-elm/compiler) or on [Discord](https://is.gd/elmdiscord)!
 
 -}
+
+-- TODO we'll probably have to detect cycles and do something like IIFE
 
 import AssocList
 import AssocSet
@@ -46,13 +46,31 @@ import Result.Extra as Result
 import Set exposing (Set)
 
 
-projectToDeclarationList : Project Typed.ProjectFields -> Result EmitError (List (Declaration Typed.LocatedExpr))
+{-| Find the shortest path through the declarations to `main`.
+
+Return the ordered list of these dependencies (`main` goes last).
+
+Automatically removes unused top-level declarations.
+
+-}
+projectToDeclarationList :
+    Project Typed.ProjectFields
+    -> Result EmitError (List (Declaration Typed.LocatedExpr))
 projectToDeclarationList { mainModuleName, modules } =
     modulesToGraph mainModuleName modules
         |> Result.map (findPathToMain mainModuleName)
 
 
-modulesToDeclarationLists : Project Typed.ProjectFields -> Result EmitError (Dict ModuleName (List (Declaration Typed.LocatedExpr)))
+{-| Find the shortest path through the declarations to all the exposed declarations.
+
+Return the ordered list of these dependencies (`main` goes last).
+
+Automatically removes unused top-level declarations.
+
+-}
+modulesToDeclarationLists :
+    Project Typed.ProjectFields
+    -> Result EmitError (Dict ModuleName (List (Declaration Typed.LocatedExpr)))
 modulesToDeclarationLists ({ mainModuleName, modules } as project) =
     modulesToGraph mainModuleName modules
         |> Result.map (findPathForEachModule project)
@@ -72,9 +90,13 @@ findPathToMain mainModuleName programGraph =
         (Set.singleton ( mainModuleName, "main" ))
 
 
-{-| In this case we don't have `main`s but TODO finish writing this
+{-| In this case we don't have `main`s but we'll use the exposed declarations in
+each of the modules.
 -}
-findPathForEachModule : Project Typed.ProjectFields -> Graph -> Dict ModuleName (List (Declaration Typed.LocatedExpr))
+findPathForEachModule :
+    Project Typed.ProjectFields
+    -> Graph
+    -> Dict ModuleName (List (Declaration Typed.LocatedExpr))
 findPathForEachModule project graph =
     let
         exposedDeclarations : Set ( ModuleName, VarName )
@@ -117,7 +139,7 @@ findPathForEachModule project graph =
 
 
 {-| Generic function to find a good ordering of values (so that all the
-dependencies are emitted before the TODO finish writing this
+dependencies are emitted before the `startingDeclarations`).
 -}
 findPath : Graph -> Set ( ModuleName, VarName ) -> List (Declaration Typed.LocatedExpr)
 findPath graph startingDeclarations =

--- a/src/Elm/Compiler/Stage/Emit.elm
+++ b/src/Elm/Compiler/Stage/Emit.elm
@@ -1,4 +1,4 @@
-module Stage.Emit exposing
+module Elm.Compiler.Stage.Emit exposing
     ( projectToDeclarationList
     , modulesToDeclarationLists
     )

--- a/src/Elm/Compiler/Stage/Emit/JS.elm
+++ b/src/Elm/Compiler/Stage/Emit/JS.elm
@@ -1,17 +1,19 @@
-module Elm.Compiler.Stage.Emit.JavaScript exposing
+module Elm.Compiler.Stage.Emit.JS exposing
     ( emitProject
     , emitDeclaration, emitExpr
     )
 
-{-| The `emitProject` function is the main entrypoint in this module, ie. every
+{-| Emit JavaScript code from the [typed AST](Elm.AST.Typed).
+
+The `emitProject` function is the main entrypoint in this module, ie. every
 `Stage.Emit.<INSERT LANGUAGE HERE>` module has to expose this function to fit
-well with the APIs of the other stages. See src/cli/Main.elm and its `compile`
+well with the APIs of the other stages. See `src/cli/Main.elm` and its `compile`
 function for example usage.
 
 @docs emitProject
 
 All the other exposed functions are (as of time of writing) exposed only for
-testing purposes.
+testing purposes:
 
 @docs emitDeclaration, emitExpr
 
@@ -33,6 +35,8 @@ type alias ProjectFields =
     { declarationList : List (Declaration Typed.LocatedExpr) }
 
 
+{-| Return a dict with a single `out.js` file with the compiled JavaScript code.
+-}
 emitProject : Project Typed.ProjectFields -> Result Error (Dict FilePath FileContents)
 emitProject project =
     Ok project
@@ -63,6 +67,7 @@ emitProject_ { declarationList } =
         |> Dict.singleton "out.js"
 
 
+{-| -}
 emitExpr : Typed.LocatedExpr -> String
 emitExpr located =
     case Typed.getExpr located of
@@ -136,6 +141,7 @@ emitExpr located =
             "[" ++ emitExpr e1 ++ "," ++ emitExpr e2 ++ "," ++ emitExpr e3 ++ "]"
 
 
+{-| -}
 emitDeclaration : Declaration Typed.LocatedExpr -> String
 emitDeclaration { module_, name, body } =
     case body of

--- a/src/Elm/Compiler/Stage/Emit/JavaScript.elm
+++ b/src/Elm/Compiler/Stage/Emit/JavaScript.elm
@@ -1,4 +1,4 @@
-module Stage.Emit.JavaScript exposing
+module Elm.Compiler.Stage.Emit.JavaScript exposing
     ( emitProject
     , emitDeclaration, emitExpr
     )
@@ -20,13 +20,13 @@ testing purposes.
 import Dict exposing (Dict)
 import Elm.AST.Typed as Typed exposing (Expr_(..))
 import Elm.Compiler.Error exposing (Error(..))
+import Elm.Compiler.Stage.Emit as Emit
 import Elm.Data.Declaration exposing (Declaration, DeclarationBody(..))
 import Elm.Data.FileContents as FileContents exposing (FileContents)
 import Elm.Data.FilePath as FilePath exposing (FilePath)
 import Elm.Data.ModuleName as ModuleName exposing (ModuleName)
 import Elm.Data.Project exposing (Project)
 import Elm.Data.VarName as VarName exposing (VarName)
-import Stage.Emit as Emit
 
 
 type alias ProjectFields =

--- a/src/Elm/Compiler/Stage/InferTypes.elm
+++ b/src/Elm/Compiler/Stage/InferTypes.elm
@@ -1,16 +1,16 @@
-module Stage.InferTypes exposing (inferExpr, inferTypes)
+module Elm.Compiler.Stage.InferTypes exposing (inferExpr, inferTypes)
 
 import Elm.AST.Canonical as Canonical
 import Elm.AST.Typed as Typed
 import Elm.Compiler.Error exposing (Error(..), TypeError(..))
+import Elm.Compiler.Stage.InferTypes.AssignIds as AssignIds
+import Elm.Compiler.Stage.InferTypes.Boilerplate as Boilerplate
+import Elm.Compiler.Stage.InferTypes.GenerateEquations as GenerateEquations
+import Elm.Compiler.Stage.InferTypes.SubstitutionMap as SubstitutionMap exposing (SubstitutionMap)
+import Elm.Compiler.Stage.InferTypes.Unify as Unify
 import Elm.Data.Located as Located
 import Elm.Data.Project exposing (Project)
 import Elm.Data.Type exposing (Type(..))
-import Stage.InferTypes.AssignIds as AssignIds
-import Stage.InferTypes.Boilerplate as Boilerplate
-import Stage.InferTypes.GenerateEquations as GenerateEquations
-import Stage.InferTypes.SubstitutionMap as SubstitutionMap exposing (SubstitutionMap)
-import Stage.InferTypes.Unify as Unify
 
 
 {-| We're using Hindley-Milner algorithm (Algorithm W). It has essentially

--- a/src/Elm/Compiler/Stage/InferTypes/AssignIds.elm
+++ b/src/Elm/Compiler/Stage/InferTypes/AssignIds.elm
@@ -1,4 +1,4 @@
-module Stage.InferTypes.AssignIds exposing (assignIds)
+module Elm.Compiler.Stage.InferTypes.AssignIds exposing (assignIds)
 
 {-| Stage 1
 
@@ -42,9 +42,9 @@ Output:
 import Dict
 import Elm.AST.Canonical as Canonical
 import Elm.AST.Typed as Typed
+import Elm.Compiler.Stage.InferTypes.IdSource as IdSource exposing (IdSource)
 import Elm.Data.Located as Located
 import Elm.Data.Type as Type
-import Stage.InferTypes.IdSource as IdSource exposing (IdSource)
 
 
 assignIds : Canonical.LocatedExpr -> ( Typed.LocatedExpr, IdSource )

--- a/src/Elm/Compiler/Stage/InferTypes/Boilerplate.elm
+++ b/src/Elm/Compiler/Stage/InferTypes/Boilerplate.elm
@@ -1,4 +1,4 @@
-module Stage.InferTypes.Boilerplate exposing
+module Elm.Compiler.Stage.InferTypes.Boilerplate exposing
     ( inferModule
     , inferProject
     )

--- a/src/Elm/Compiler/Stage/InferTypes/GenerateEquations.elm
+++ b/src/Elm/Compiler/Stage/InferTypes/GenerateEquations.elm
@@ -1,4 +1,4 @@
-module Stage.InferTypes.GenerateEquations exposing (generateEquations)
+module Elm.Compiler.Stage.InferTypes.GenerateEquations exposing (generateEquations)
 
 {-| Stage 2
 
@@ -31,11 +31,11 @@ subexpression.
 
 import Dict
 import Elm.AST.Typed as Typed
+import Elm.Compiler.Stage.InferTypes.IdSource as IdSource exposing (IdSource)
+import Elm.Compiler.Stage.InferTypes.TypeEquation exposing (TypeEquation, equals)
 import Elm.Data.Located as Located
 import Elm.Data.Type as Type
 import Elm.Data.VarName exposing (VarName)
-import Stage.InferTypes.IdSource as IdSource exposing (IdSource)
-import Stage.InferTypes.TypeEquation exposing (TypeEquation, equals)
 import Transform
 
 

--- a/src/Elm/Compiler/Stage/InferTypes/IdSource.elm
+++ b/src/Elm/Compiler/Stage/InferTypes/IdSource.elm
@@ -1,4 +1,4 @@
-module Stage.InferTypes.IdSource exposing
+module Elm.Compiler.Stage.InferTypes.IdSource exposing
     ( IdSource
     , empty
     , increment

--- a/src/Elm/Compiler/Stage/InferTypes/SubstitutionMap.elm
+++ b/src/Elm/Compiler/Stage/InferTypes/SubstitutionMap.elm
@@ -1,4 +1,4 @@
-module Stage.InferTypes.SubstitutionMap exposing
+module Elm.Compiler.Stage.InferTypes.SubstitutionMap exposing
     ( SubstitutionMap
     , empty
     , get

--- a/src/Elm/Compiler/Stage/InferTypes/TypeEquation.elm
+++ b/src/Elm/Compiler/Stage/InferTypes/TypeEquation.elm
@@ -1,4 +1,4 @@
-module Stage.InferTypes.TypeEquation exposing
+module Elm.Compiler.Stage.InferTypes.TypeEquation exposing
     ( TypeEquation
     , equals
     , unwrap

--- a/src/Elm/Compiler/Stage/InferTypes/Unify.elm
+++ b/src/Elm/Compiler/Stage/InferTypes/Unify.elm
@@ -1,9 +1,9 @@
-module Stage.InferTypes.Unify exposing (unifyAllEquations)
+module Elm.Compiler.Stage.InferTypes.Unify exposing (unifyAllEquations)
 
 import Elm.Compiler.Error exposing (TypeError(..))
+import Elm.Compiler.Stage.InferTypes.SubstitutionMap as SubstitutionMap exposing (SubstitutionMap)
+import Elm.Compiler.Stage.InferTypes.TypeEquation as TypeEquation exposing (TypeEquation)
 import Elm.Data.Type as Type exposing (Type(..))
-import Stage.InferTypes.SubstitutionMap as SubstitutionMap exposing (SubstitutionMap)
-import Stage.InferTypes.TypeEquation as TypeEquation exposing (TypeEquation)
 
 
 {-| TODO document

--- a/src/Elm/Compiler/Stage/Optimize.elm
+++ b/src/Elm/Compiler/Stage/Optimize.elm
@@ -1,4 +1,4 @@
-module Stage.Optimize exposing
+module Elm.Compiler.Stage.Optimize exposing
     ( defaultOptimizations
     , optimize
     , optimizeExpr
@@ -6,8 +6,8 @@ module Stage.Optimize exposing
     )
 
 import Elm.AST.Typed as Typed
+import Elm.Compiler.Stage.Optimize.Boilerplate as Boilerplate
 import Elm.Data.Project exposing (Project)
-import Stage.Optimize.Boilerplate as Boilerplate
 
 
 optimize : Project Typed.ProjectFields -> Project Typed.ProjectFields

--- a/src/Elm/Compiler/Stage/Optimize/Boilerplate.elm
+++ b/src/Elm/Compiler/Stage/Optimize/Boilerplate.elm
@@ -1,4 +1,4 @@
-module Stage.Optimize.Boilerplate exposing
+module Elm.Compiler.Stage.Optimize.Boilerplate exposing
     ( optimizeModule
     , optimizeProject
     )

--- a/src/Elm/Compiler/Stage/Parse.elm
+++ b/src/Elm/Compiler/Stage/Parse.elm
@@ -1,13 +1,13 @@
-module Stage.Parse exposing (parse)
+module Elm.Compiler.Stage.Parse exposing (parse)
 
 import Elm.AST.Frontend as Frontend
 import Elm.Compiler.Error exposing (Error(..), ParseError(..))
+import Elm.Compiler.Stage.Parse.Parser as Parser
 import Elm.Data.FileContents exposing (FileContents)
 import Elm.Data.FilePath exposing (FilePath)
 import Elm.Data.Module exposing (Module)
 import Elm.Data.ModuleName as ModuleName exposing (ModuleName)
 import Parser.Advanced as P
-import Stage.Parse.Parser as Parser
 
 
 {-| This `parse` function is used only by cli/, not by library/.

--- a/src/Elm/Compiler/Stage/Parse/Parser.elm
+++ b/src/Elm/Compiler/Stage/Parse/Parser.elm
@@ -1,4 +1,4 @@
-module Stage.Parse.Parser exposing
+module Elm.Compiler.Stage.Parse.Parser exposing
     ( declaration
     , exposingList
     , expr

--- a/tests/EmitTest.elm
+++ b/tests/EmitTest.elm
@@ -2,13 +2,13 @@ module EmitTest exposing (javascript)
 
 import Dict
 import Elm.AST.Typed as Typed exposing (Expr_(..), LocatedExpr)
+import Elm.Compiler.Stage.Emit.JavaScript as JS
 import Elm.Data.Declaration exposing (Declaration, DeclarationBody(..))
 import Elm.Data.Located as Located exposing (Located)
 import Elm.Data.ModuleName as ModuleName exposing (ModuleName)
 import Elm.Data.Type as Type
 import Elm.Data.VarName as VarName exposing (VarName)
 import Expect exposing (Expectation)
-import Stage.Emit.JavaScript as JS
 import Test exposing (Test, describe, test, todo)
 import TestHelpers
     exposing

--- a/tests/InferTypesFuzz.elm
+++ b/tests/InferTypesFuzz.elm
@@ -4,6 +4,7 @@ import Elm.AST.Canonical as Canonical
 import Elm.AST.Canonical.Unwrapped as CanonicalU
 import Elm.AST.Typed as Typed
 import Elm.Compiler.Error exposing (TypeError(..))
+import Elm.Compiler.Stage.InferTypes as InferTypes
 import Elm.Data.Located as Located
 import Elm.Data.Type as Type exposing (Type)
 import Elm.Data.VarName as VarName exposing (VarName)
@@ -13,7 +14,6 @@ import Random exposing (Generator)
 import Random.Extra as Random
 import Shrink exposing (Shrinker)
 import Shrink.Extra as Shrink
-import Stage.InferTypes
 import Test exposing (Test, describe, fuzz, test)
 import TestHelpers exposing (dumpType)
 
@@ -27,7 +27,7 @@ typeInference =
                 \input ->
                     input
                         |> Canonical.fromUnwrapped
-                        |> Stage.InferTypes.inferExpr
+                        |> InferTypes.inferExpr
                         |> Result.map Located.unwrap
                         |> Result.map Tuple.second
                         |> Expect.equal (Ok typeWanted)

--- a/tests/InferTypesTest.elm
+++ b/tests/InferTypesTest.elm
@@ -4,6 +4,7 @@ import Elm.AST.Canonical as Canonical
 import Elm.AST.Canonical.Unwrapped as CanonicalU
 import Elm.AST.Typed as Typed
 import Elm.Compiler.Error as Error exposing (Error(..), TypeError(..))
+import Elm.Compiler.Stage.InferTypes as InferTypes
 import Elm.Data.Located as Located
 import Elm.Data.ModuleName as ModuleName exposing (ModuleName)
 import Elm.Data.Type as Type exposing (Type(..))
@@ -11,7 +12,6 @@ import Elm.Data.Type.ToString as TypeToString
 import Elm.Data.VarName as VarName exposing (VarName)
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer)
-import Stage.InferTypes
 import Test exposing (Test, describe, fuzz, test)
 import TestHelpers exposing (dumpType, located)
 
@@ -30,7 +30,7 @@ typeInference =
                 \() ->
                     input
                         |> Canonical.fromUnwrapped
-                        |> Stage.InferTypes.inferExpr
+                        |> InferTypes.inferExpr
                         |> Result.map Typed.getType
                         |> Expect.equal output
     in

--- a/tests/OptimizeTest.elm
+++ b/tests/OptimizeTest.elm
@@ -1,13 +1,13 @@
 module OptimizeTest exposing (optimize)
 
 import Elm.AST.Typed as Typed exposing (Expr_(..))
+import Elm.Compiler.Stage.Optimize as Optimize
 import Elm.Data.Declaration exposing (Declaration)
 import Elm.Data.Located as Located exposing (Located)
 import Elm.Data.ModuleName as ModuleName exposing (ModuleName)
 import Elm.Data.Type as Type
 import Elm.Data.VarName as VarName exposing (VarName)
 import Expect exposing (Expectation)
-import Stage.Optimize
 import Test exposing (Test, describe, test, todo)
 import TestHelpers
     exposing
@@ -27,7 +27,7 @@ optimize =
                 test description <|
                     \() ->
                         input
-                            |> Stage.Optimize.optimizeExpr
+                            |> Optimize.optimizeExpr
                             |> Expect.equal output
           in
           describe "optimizeExpr"

--- a/tests/ParserTest.elm
+++ b/tests/ParserTest.elm
@@ -10,6 +10,7 @@ import Dict
 import Elm.AST.Frontend as Frontend
 import Elm.AST.Frontend.Unwrapped exposing (Expr(..))
 import Elm.Compiler.Error exposing (ParseContext, ParseProblem)
+import Elm.Compiler.Stage.Parse.Parser as Parser
 import Elm.Data.Exposing exposing (ExposedItem(..), Exposing(..))
 import Elm.Data.Module exposing (ModuleType(..))
 import Elm.Data.ModuleName as ModuleName exposing (ModuleName)
@@ -17,7 +18,6 @@ import Elm.Data.VarName as VarName exposing (VarName)
 import Expect exposing (Expectation)
 import Parser.Advanced as P
 import Result.Extra
-import Stage.Parse.Parser
 import Test exposing (Test, describe, test)
 
 
@@ -28,7 +28,7 @@ moduleDeclaration =
             test description <|
                 \() ->
                     input
-                        |> P.run Stage.Parse.Parser.moduleDeclaration
+                        |> P.run Parser.moduleDeclaration
                         |> Result.toMaybe
                         |> Expect.equal output
     in
@@ -99,7 +99,7 @@ exposingList =
             test description <|
                 \() ->
                     input
-                        |> P.run Stage.Parse.Parser.exposingList
+                        |> P.run Parser.exposingList
                         |> Result.toMaybe
                         |> Expect.equal output
     in
@@ -209,7 +209,7 @@ imports =
             test description <|
                 \() ->
                     input
-                        |> P.run Stage.Parse.Parser.imports
+                        |> P.run Parser.imports
                         |> Result.toMaybe
                         |> Expect.equal output
     in
@@ -366,7 +366,7 @@ moduleName =
             test description <|
                 \() ->
                     input
-                        |> P.run Stage.Parse.Parser.moduleName
+                        |> P.run Parser.moduleName
                         |> Result.toMaybe
                         |> Expect.equal output
     in
@@ -426,7 +426,7 @@ expr =
             test description <|
                 \() ->
                     input
-                        |> P.run Stage.Parse.Parser.expr
+                        |> P.run Parser.expr
                         |> Result.map Frontend.unwrap
                         |> expectEqualParseResult input output
     in


### PR DESCRIPTION
- [ ] add `compileToJS` - surprisingly, the whole `Elm.Compiler` API works without `Project` and `ProjectFields`, but suddenly `Emit.JS` needs it. Maybe rethink how should it fit together!
- [ ] fix / work around package.elm-lang.org not showing `Typed.Expr` but just `Expr`. So far I'm creating an alias `TypedExpr` but I don't like it...