### PR TITLE
make the InferTypes.unify case more explicit

### DIFF
--- a/src/Elm/Data/Type.elm
+++ b/src/Elm/Data/Type.elm
@@ -12,22 +12,7 @@ import Elm.Data.VarName exposing (VarName)
 
 {-| -}
 type Type
-    = {- READ THIS!
-
-         When adding a case that recurs on Type, you'll have to add a case to
-         `InferTypes.Unify.unify`:
-
-             | MyNewType Type Type
-
-         will have to get a case:
-
-             (MyNewType m1e1 m1e2, MyNewType m2e1 m2e2) ->
-                 substitutionMap
-                     |> unify m1e1 m2e1
-                     |> Result.andThen (unify m1e2 m2e2)
-
-      -}
-      Var Int
+    = Var Int
     | Function Type Type
     | Int
     | Float

--- a/src/Stage/InferTypes/Unify.elm
+++ b/src/Stage/InferTypes/Unify.elm
@@ -39,8 +39,8 @@ unify t1 t2 substitutionMap =
                  ( T _ _, _) ->
                      Err ( TypeMismatch t1 t2, substitutionMap )
 
-               It is definitively verbose but prevent the developer to skip this important
-               function: the compiler will throw an "MISSING PATTERNS" in this case.
+               It is definitively verbose but prevents the developer to skip this important
+               function: the compiler will throw a "MISSING PATTERNS" error in this case.
             -}
             ( Var id, _ ) ->
                 unifyVariable id t2 substitutionMap


### PR DESCRIPTION
Problem: when a newcomer contributes to the project
for the first time, the comment in Elm/Data/Type.elm asking for adding
a case in the InfertTypes.unify function is meaningless
since the developer does not understand what this comment
is talking about. Thus, the developer could skip this comment,
leading to hard-to-find bug instead of easily understandable
compiler error message.

Indeed, the unify function pattern matchs against the Joker pattern "_"
at the end, silently ignoring new types.

Solution: Remove Joker pattern and pattern match against
    (T a b, T c d)

AND
    (T _ _, _)
for all types T.

There still is a comment, but this one is more local than the previous one.
Moreover this comment just asks "please do the same" instead of
"please do a specific thing".