### PR TITLE
Add emitter for AST data in JSON format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ run: build
 	tput reset
 	@node cli/index.js
 
+.PHONY: json
+json: build
+	tput reset
+	@node cli/index.js -o JSON
+
 .PHONY: build
 build:
 	rm -rf build/elm.js elm-stuff

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,10 +1,10 @@
 const fs = require('fs').promises; // needs Node.JS v10+
 
-const {Elm}          = require('../build/elm.js'); // build using Makefile... no Webpack around here!
-const {registerPort} = require('./utils.js');
+const { Elm } = require('../build/elm.js'); // build using Makefile... no Webpack around here!
+const { registerPort } = require('./utils.js');
 
 // Async/await is nice! (needs Node.JS v7.6+)
-(async function(){
+(async function () {
 
   console.log('---------------------------');
   console.log('-- STARTING THE COMPILER --');
@@ -15,7 +15,8 @@ const {registerPort} = require('./utils.js');
   const app = Elm.Main.init({
     flags: {
       mainFilePath: 'src/Main.elm',
-      elmJson: await fs.readFile(`${exampleProjectPath}/elm.json`, {encoding: 'utf8'}),
+      elmJson: await fs.readFile(`${exampleProjectPath}/elm.json`, { encoding: 'utf8' }),
+      outputFormat: "JavaScript" // alternative "JSON"
     }
   });
 
@@ -27,9 +28,9 @@ const {registerPort} = require('./utils.js');
     process.stderr.write('\n---------------------------');
     process.stderr.write(`\n${string}`);
   });
-  registerPort(app, 'read', async function(filename) {
+  registerPort(app, 'read', async function (filename) {
     try {
-      const contents = await fs.readFile(`${exampleProjectPath}/${filename}`, {encoding: 'utf8'});
+      const contents = await fs.readFile(`${exampleProjectPath}/${filename}`, { encoding: 'utf8' });
       app.ports.readSubscription.send({
         filePath: filename,
         fileContents: contents,
@@ -47,7 +48,7 @@ const {registerPort} = require('./utils.js');
       }
     }
   });
-  registerPort(app, 'writeToFile', async function({filePath,fileContents}) {
+  registerPort(app, 'writeToFile', async function ({ filePath, fileContents }) {
     console.log('---------------------------');
     console.log('-- WRITING TO FS ----------');
     console.log('---------------------------');

--- a/cli/index.js
+++ b/cli/index.js
@@ -6,6 +6,25 @@ const { registerPort } = require('./utils.js');
 // Async/await is nice! (needs Node.JS v7.6+)
 (async function () {
 
+  // process command line arguments
+  const yargs = require('yargs')
+  const argv = yargs
+    .option('main', {
+      alias: 'm',
+      description: 'The main Elm file',
+      type: 'string',
+      default: 'src/Main.elm'
+    })
+    .option('output', {
+      alias: 'o',
+      description: 'The format to emit: JavaScript or JSON',
+      type: 'string',
+      default: 'JavaScript'
+    })
+    .help()
+    .alias('help', 'h')
+    .argv;
+
   console.log('---------------------------');
   console.log('-- STARTING THE COMPILER --');
   console.log('---------------------------');
@@ -14,9 +33,9 @@ const { registerPort } = require('./utils.js');
 
   const app = Elm.Main.init({
     flags: {
-      mainFilePath: 'src/Main.elm',
+      mainFilePath: argv.main,
       elmJson: await fs.readFile(`${exampleProjectPath}/elm.json`, { encoding: 'utf8' }),
-      outputFormat: "JavaScript" // alternative "JSON"
+      outputFormat: argv.output
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
     },
     "devDependencies": {
         "elm-test": "^0.19.1"
+    },
+    "dependencies": {
+        "yargs": "^15.0.2"
     }
 }

--- a/src/Stage/Emit/Common.elm
+++ b/src/Stage/Emit/Common.elm
@@ -1,0 +1,49 @@
+module Stage.Emit.Common exposing
+    ( mangleModuleName
+    , mangleQualifiedVar
+    , mangleVarName
+    , prepareProjectFields
+    )
+
+import Elm.AST.Typed as Typed exposing (Expr_(..))
+import Elm.Compiler.Error exposing (Error(..))
+import Elm.Data.Declaration exposing (Declaration, DeclarationBody(..))
+import Elm.Data.ModuleName exposing (ModuleName)
+import Elm.Data.Project exposing (Project)
+import Elm.Data.VarName exposing (VarName)
+import Stage.Emit as Emit
+
+
+type alias ProjectFields =
+    { declarationList : List (Declaration Typed.LocatedExpr) }
+
+
+prepareProjectFields : Project Typed.ProjectFields -> Result Error (Project ProjectFields)
+prepareProjectFields project =
+    Emit.projectToDeclarationList project
+        |> Result.mapError EmitError
+        |> Result.map
+            (\declarationList ->
+                { mainFilePath = project.mainFilePath
+                , mainModuleName = project.mainModuleName
+                , elmJson = project.elmJson
+                , sourceDirectory = project.sourceDirectory
+                , declarationList = declarationList
+                }
+            )
+
+
+mangleQualifiedVar : { module_ : ModuleName, name : VarName } -> String
+mangleQualifiedVar { module_, name } =
+    mangleModuleName module_ ++ "$" ++ mangleVarName name
+
+
+mangleModuleName : ModuleName -> String
+mangleModuleName moduleName =
+    String.replace "." "$" moduleName
+
+
+mangleVarName : VarName -> String
+mangleVarName varName =
+    -- TODO this does nothing currently... what does the official Elm compiler do?
+    varName

--- a/src/Stage/Emit/JavaScript.elm
+++ b/src/Stage/Emit/JavaScript.elm
@@ -21,12 +21,10 @@ import Dict exposing (Dict)
 import Elm.AST.Typed as Typed exposing (Expr_(..))
 import Elm.Compiler.Error exposing (Error(..))
 import Elm.Data.Declaration exposing (Declaration, DeclarationBody(..))
-import Elm.Data.FileContents as FileContents exposing (FileContents)
-import Elm.Data.FilePath as FilePath exposing (FilePath)
-import Elm.Data.ModuleName as ModuleName exposing (ModuleName)
+import Elm.Data.FileContents exposing (FileContents)
+import Elm.Data.FilePath exposing (FilePath)
 import Elm.Data.Project exposing (Project)
-import Elm.Data.VarName as VarName exposing (VarName)
-import Stage.Emit as Emit
+import Stage.Emit.Common exposing (mangleQualifiedVar, mangleVarName, prepareProjectFields)
 
 
 type alias ProjectFields =
@@ -38,21 +36,6 @@ emitProject project =
     Ok project
         |> Result.andThen prepareProjectFields
         |> Result.map emitProject_
-
-
-prepareProjectFields : Project Typed.ProjectFields -> Result Error (Project ProjectFields)
-prepareProjectFields project =
-    Emit.projectToDeclarationList project
-        |> Result.mapError EmitError
-        |> Result.map
-            (\declarationList ->
-                { mainFilePath = project.mainFilePath
-                , mainModuleName = project.mainModuleName
-                , elmJson = project.elmJson
-                , sourceDirectory = project.sourceDirectory
-                , declarationList = declarationList
-                }
-            )
 
 
 emitProject_ : Project ProjectFields -> Dict FilePath FileContents
@@ -161,19 +144,3 @@ emitDeclaration { module_, name, body } =
 
         CustomType _ ->
             ""
-
-
-mangleQualifiedVar : { module_ : ModuleName, name : VarName } -> String
-mangleQualifiedVar { module_, name } =
-    mangleModuleName module_ ++ "$" ++ mangleVarName name
-
-
-mangleModuleName : ModuleName -> String
-mangleModuleName moduleName =
-    String.replace "." "$" moduleName
-
-
-mangleVarName : VarName -> String
-mangleVarName varName =
-    -- TODO this does nothing currently... what does the official Elm compiler do?
-    varName

--- a/src/Stage/Emit/JsonAST.elm
+++ b/src/Stage/Emit/JsonAST.elm
@@ -1,0 +1,221 @@
+module Stage.Emit.JsonAST exposing
+    ( emitProject
+    , emitDeclaration, emitExpr
+    )
+
+{-| The `emitProject` function is the main entrypoint in this module, ie. every
+`Stage.Emit.<INSERT LANGUAGE HERE>` module has to expose this function to fit
+well with the APIs of the other stages. See cli/Main.elm and its `compile`
+function for example usage.
+
+@docs emitProject
+
+All the other exposed functions are (as of time of writing) exposed only for
+testing purposes.
+
+@docs emitDeclaration, emitExpr
+
+-}
+
+import Dict exposing (Dict)
+import Elm.AST.Typed as Typed exposing (Expr_(..))
+import Elm.Compiler.Error exposing (Error(..))
+import Elm.Data.Declaration exposing (Declaration, DeclarationBody(..))
+import Elm.Data.FileContents exposing (FileContents)
+import Elm.Data.FilePath exposing (FilePath)
+import Elm.Data.ModuleName exposing (ModuleName)
+import Elm.Data.Project exposing (Project)
+import Elm.Data.VarName exposing (VarName)
+import Stage.Emit as Emit
+
+
+type alias ProjectFields =
+    { declarationList : List (Declaration Typed.LocatedExpr) }
+
+
+emitProject : Project Typed.ProjectFields -> Result Error (Dict FilePath FileContents)
+emitProject project =
+    Ok project
+        |> Result.andThen prepareProjectFields
+        |> Result.map emitProject_
+
+
+prepareProjectFields : Project Typed.ProjectFields -> Result Error (Project ProjectFields)
+prepareProjectFields project =
+    Emit.projectToDeclarationList project
+        |> Result.mapError EmitError
+        |> Result.map
+            (\declarationList ->
+                { mainFilePath = project.mainFilePath
+                , mainModuleName = project.mainModuleName
+                , elmJson = project.elmJson
+                , sourceDirectory = project.sourceDirectory
+                , declarationList = declarationList
+                }
+            )
+
+
+emitProject_ : Project ProjectFields -> Dict FilePath FileContents
+emitProject_ { declarationList } =
+    let
+        declarations =
+            declarationList
+                |> List.map emitDeclaration
+    in
+    Dict.singleton "out.json" ("[" ++ String.join "," declarations ++ "]")
+
+
+toJson : String -> List ( String, String ) -> String
+toJson astType fields =
+    (quote "type" ++ ":" ++ quote astType)
+        :: List.map (\( k, v ) -> quote k ++ ":" ++ v) fields
+        |> brace
+
+
+quote : String -> String
+quote s =
+    "\"" ++ s ++ "\""
+
+
+brace : List String -> String
+brace s =
+    "{" ++ String.join "," s ++ "}"
+
+
+fromFloat : Float -> String
+fromFloat f =
+    if isNaN f || isInfinite f then
+        quote (String.fromFloat f)
+
+    else
+        String.fromFloat f
+
+
+emitExpr : Typed.LocatedExpr -> String
+emitExpr located =
+    case Typed.getExpr located of
+        Int int ->
+            toJson "int"
+                [ ( "value", String.fromInt int ) ]
+
+        Float float ->
+            toJson "float" [ ( "value", fromFloat float ) ]
+
+        Char char ->
+            toJson "char" [ ( "value", quote (String.fromChar char) ) ]
+
+        String string ->
+            toJson "string" [ ( "value", quote string ) ]
+
+        Bool bool ->
+            if bool then
+                toJson "bool" [ ( "value", "true" ) ]
+
+            else
+                toJson "bool" [ ( "value", "false" ) ]
+
+        Var var ->
+            toJson "var" [ ( "name", quote (mangleQualifiedVar var) ) ]
+
+        Argument argument ->
+            toJson "arg" [ ( "name", quote argument ) ]
+
+        Plus e1 e2 ->
+            toJson "plus"
+                [ ( "e1", emitExpr e1 )
+                , ( "e2", emitExpr e2 )
+                ]
+
+        Cons e1 e2 ->
+            toJson "cons"
+                [ ( "e1", emitExpr e1 )
+                , ( "e2", emitExpr e2 )
+                ]
+
+        Lambda { argument, body } ->
+            toJson "lambda"
+                [ ( "arg", quote argument )
+                , ( "body", emitExpr body )
+                ]
+
+        Call { fn, argument } ->
+            toJson "call"
+                [ ( "fn", emitExpr fn )
+                , ( "arg", emitExpr argument )
+                ]
+
+        If { test, then_, else_ } ->
+            toJson "if"
+                [ ( "test", emitExpr test )
+                , ( "then", emitExpr then_ )
+                , ( "else", emitExpr else_ )
+                ]
+
+        Let { bindings, body } ->
+            let
+                {- TODO this doesn't take inter-let dependencies into account, also Dict.values just returns stuff "randomly" -}
+                assignments =
+                    bindings
+                        |> Dict.values
+                        |> List.map (\binding -> quote binding.name ++ ":" ++ emitExpr binding.body)
+            in
+            toJson "let"
+                [ ( "bind", brace assignments )
+                , ( "body", emitExpr body )
+                ]
+
+        List items ->
+            toJson "list"
+                [ ( "items", "[" ++ (List.map emitExpr items |> String.join ",") ++ "]" )
+                ]
+
+        Unit ->
+            toJson "unit" []
+
+        Tuple e1 e2 ->
+            toJson "tuple"
+                [ ( "e1", emitExpr e1 )
+                , ( "e2", emitExpr e2 )
+                ]
+
+        Tuple3 e1 e2 e3 ->
+            toJson "tuple"
+                [ ( "e1", emitExpr e1 )
+                , ( "e2", emitExpr e2 )
+                , ( "e3", emitExpr e3 )
+                ]
+
+        Record bindings ->
+            let
+                entries =
+                    bindings
+                        |> Dict.values
+                        |> List.map (\binding -> quote binding.name ++ ":" ++ emitExpr binding.body)
+            in
+            toJson "record" [ ( "bind", brace entries ) ]
+
+
+emitDeclaration : Declaration Typed.LocatedExpr -> String
+emitDeclaration { module_, name, body } =
+    case body of
+        Value expr ->
+            toJson "decl"
+                [ ( "name", quote (module_ ++ "$" ++ name) )
+                , ( "expr", emitExpr expr )
+                ]
+
+        TypeAlias _ ->
+            ""
+
+        CustomType _ ->
+            ""
+
+
+mangleQualifiedVar : { module_ : ModuleName, name : VarName } -> String
+mangleQualifiedVar { module_, name } =
+    mangleModuleName module_ ++ "$" ++ name
+
+
+mangleModuleName : ModuleName -> String
+mangleModuleName moduleName =
+    String.replace "." "$" moduleName

--- a/tests/EmitJsonTest.elm
+++ b/tests/EmitJsonTest.elm
@@ -5,6 +5,7 @@ import Elm.AST.Typed as Typed exposing (Expr_(..))
 import Elm.Data.Declaration exposing (Declaration, DeclarationBody(..))
 import Expect
 import Fuzz exposing (bool, char, float, int, string)
+import Json.Encode as E
 import Stage.Emit.JsonAST as JSON
 import Test exposing (Test, describe, fuzz, test)
 import TestHelpers
@@ -33,30 +34,35 @@ json =
                 \x ->
                     typedInt x
                         |> JSON.emitExpr
+                        |> E.encode 0
                         |> Expect.equal
                             ("{\"type\":\"int\",\"value\":" ++ String.fromInt x ++ "}")
             , fuzz float "encode float" <|
                 \x ->
                     typed (Float x)
                         |> JSON.emitExpr
+                        |> E.encode 0
                         |> Expect.equal
                             ("{\"type\":\"float\",\"value\":" ++ String.fromFloat x ++ "}")
             , fuzz char "encode char" <|
                 \x ->
                     typed (Char x)
                         |> JSON.emitExpr
+                        |> E.encode 0
                         |> Expect.equal
-                            ("{\"type\":\"char\",\"value\":\"" ++ String.fromChar x ++ "\"}")
+                            ("{\"type\":\"char\",\"value\":" ++ E.encode 0 (E.string (String.fromChar x)) ++ "}")
             , fuzz string "encode string" <|
                 \x ->
                     typed (String x)
                         |> JSON.emitExpr
+                        |> E.encode 0
                         |> Expect.equal
-                            ("{\"type\":\"string\",\"value\":\"" ++ x ++ "\"}")
+                            ("{\"type\":\"string\",\"value\":" ++ E.encode 0 (E.string x) ++ "}")
             , fuzz bool "encode bool" <|
                 \x ->
                     typed (Bool x)
                         |> JSON.emitExpr
+                        |> E.encode 0
                         |> Expect.equal
                             ("{\"type\":\"bool\",\"value\":" ++ fromBool x ++ "}")
             ]
@@ -67,6 +73,7 @@ json =
                     \() ->
                         typed input
                             |> JSON.emitExpr
+                            |> E.encode 0
                             |> Expect.equal output
           in
           describe "emitExpr"
@@ -207,6 +214,7 @@ json =
                     \() ->
                         input
                             |> JSON.emitDeclaration
+                            |> E.encode 0
                             |> Expect.equal output
           in
           describe "emitDeclaration"

--- a/tests/EmitJsonTest.elm
+++ b/tests/EmitJsonTest.elm
@@ -1,0 +1,223 @@
+module EmitJsonTest exposing (json)
+
+import Dict
+import Elm.AST.Typed as Typed exposing (Expr_(..))
+import Elm.Data.Declaration exposing (Declaration, DeclarationBody(..))
+import Expect
+import Fuzz exposing (bool, char, float, int, string)
+import Stage.Emit.JsonAST as JSON
+import Test exposing (Test, describe, fuzz, test)
+import TestHelpers
+    exposing
+        ( typed
+        , typedInt
+        , typedIntList
+        , typedString
+        )
+
+
+fromBool : Bool -> String
+fromBool b =
+    if b then
+        "true"
+
+    else
+        "false"
+
+
+json : Test
+json =
+    describe "Stage.Emit.JsonAST"
+        [ describe "literals"
+            [ fuzz int "encode integer" <|
+                \x ->
+                    typedInt x
+                        |> JSON.emitExpr
+                        |> Expect.equal
+                            ("{\"type\":\"int\",\"value\":" ++ String.fromInt x ++ "}")
+            , fuzz float "encode float" <|
+                \x ->
+                    typed (Float x)
+                        |> JSON.emitExpr
+                        |> Expect.equal
+                            ("{\"type\":\"float\",\"value\":" ++ String.fromFloat x ++ "}")
+            , fuzz char "encode char" <|
+                \x ->
+                    typed (Char x)
+                        |> JSON.emitExpr
+                        |> Expect.equal
+                            ("{\"type\":\"char\",\"value\":\"" ++ String.fromChar x ++ "\"}")
+            , fuzz string "encode string" <|
+                \x ->
+                    typed (String x)
+                        |> JSON.emitExpr
+                        |> Expect.equal
+                            ("{\"type\":\"string\",\"value\":\"" ++ x ++ "\"}")
+            , fuzz bool "encode bool" <|
+                \x ->
+                    typed (Bool x)
+                        |> JSON.emitExpr
+                        |> Expect.equal
+                            ("{\"type\":\"bool\",\"value\":" ++ fromBool x ++ "}")
+            ]
+        , let
+            runTest : ( String, Typed.Expr_, String ) -> Test
+            runTest ( description, input, output ) =
+                test description <|
+                    \() ->
+                        typed input
+                            |> JSON.emitExpr
+                            |> Expect.equal output
+          in
+          describe "emitExpr"
+            [ describe "Var"
+                (List.map runTest
+                    [ ( "simple", Var { module_ = "Foo", name = "bar" }, "{\"type\":\"var\",\"name\":\"Foo$bar\"}" )
+                    , ( "nested", Var { module_ = "Foo.Bar", name = "baz" }, "{\"type\":\"var\",\"name\":\"Foo$Bar$baz\"}" )
+                    ]
+                )
+            , describe "Argument"
+                (List.map runTest
+                    [ ( "simple", Argument "foo", "{\"type\":\"arg\",\"name\":\"foo\"}" )
+                    ]
+                )
+            , describe "Plus"
+                (List.map runTest
+                    [ ( "simple", Plus (typedInt 1) (typedInt 2), "{\"type\":\"plus\",\"e1\":{\"type\":\"int\",\"value\":1},\"e2\":{\"type\":\"int\",\"value\":2}}" )
+                    ]
+                )
+            , describe "Cons"
+                (List.map runTest
+                    [ ( "simple"
+                      , Cons (typedInt 1) (typedIntList [ 2, 3 ])
+                      , "{\"type\":\"cons\",\"e1\":{\"type\":\"int\",\"value\":1},\"e2\":{\"type\":\"list\",\"items\":[{\"type\":\"int\",\"value\":2},{\"type\":\"int\",\"value\":3}]}}"
+                      )
+                    ]
+                )
+            , describe "Lambda"
+                (List.map runTest
+                    [ ( "simple"
+                      , Lambda { argument = "x", body = typedInt 1 }
+                      , "{\"type\":\"lambda\",\"arg\":\"x\",\"body\":{\"type\":\"int\",\"value\":1}}"
+                      )
+                    ]
+                )
+            , describe "Call"
+                (List.map runTest
+                    [ ( "simple"
+                      , Call
+                            { fn = typed (Var { module_ = "Basics", name = "negate" })
+                            , argument = typedInt 1
+                            }
+                      , "{\"type\":\"call\",\"fn\":{\"type\":\"var\",\"name\":\"Basics$negate\"},\"arg\":{\"type\":\"int\",\"value\":1}}"
+                      )
+                    ]
+                )
+            , describe "If"
+                (List.map runTest
+                    [ ( "simple - true"
+                      , If
+                            { test = typed (Bool True)
+                            , then_ = typedInt 1
+                            , else_ = typedInt 2
+                            }
+                      , "{\"type\":\"if\",\"test\":{\"type\":\"bool\",\"value\":true},\"then\":{\"type\":\"int\",\"value\":1},\"else\":{\"type\":\"int\",\"value\":2}}"
+                      )
+                    ]
+                )
+            , describe "List"
+                (List.map runTest
+                    [ ( "empty list"
+                      , List []
+                      , "{\"type\":\"list\",\"items\":[]}"
+                      )
+                    , ( "simple list"
+                      , List [ typedInt 1, typedInt 2, typedInt 3 ]
+                      , "{\"type\":\"list\",\"items\":[{\"type\":\"int\",\"value\":1},{\"type\":\"int\",\"value\":2},{\"type\":\"int\",\"value\":3}]}"
+                      )
+                    ]
+                )
+            , runTest
+                ( "Unit"
+                , Unit
+                , "{\"type\":\"unit\"}"
+                )
+            , describe "Let"
+                (List.map runTest
+                    [ ( "one binding"
+                      , Let
+                            { bindings =
+                                Dict.singleton
+                                    "x"
+                                    { name = "x"
+                                    , body = typedInt 2
+                                    }
+                            , body = typedInt 1
+                            }
+                      , "{\"type\":\"let\",\"bind\":{\"x\":{\"type\":\"int\",\"value\":2}},\"body\":{\"type\":\"int\",\"value\":1}}"
+                      )
+                    ]
+                )
+            , describe "Tuple"
+                (List.map runTest
+                    [ ( "simple tuple"
+                      , Tuple (typedInt 1) (typedInt 2)
+                      , "{\"type\":\"tuple\",\"e1\":{\"type\":\"int\",\"value\":1},\"e2\":{\"type\":\"int\",\"value\":2}}"
+                      )
+                    ]
+                )
+            , describe "Tuple3"
+                (List.map runTest
+                    [ ( "simple tuple3"
+                      , Tuple3 (typedInt 1) (typedInt 2) (typedInt 3)
+                      , "{\"type\":\"tuple\",\"e1\":{\"type\":\"int\",\"value\":1},\"e2\":{\"type\":\"int\",\"value\":2},\"e3\":{\"type\":\"int\",\"value\":3}}"
+                      )
+                    ]
+                )
+            , describe "Record"
+                (List.map runTest
+                    [ ( "record single field"
+                      , Record
+                            (Dict.fromList
+                                [ ( "a", { name = "a", body = typedInt 42 } )
+                                ]
+                            )
+                      , "{\"type\":\"record\",\"bind\":{\"a\":{\"type\":\"int\",\"value\":42}}}"
+                      )
+                    , ( "void record"
+                      , Record Dict.empty
+                      , "{\"type\":\"record\",\"bind\":{}}"
+                      )
+                    , ( "record two fields"
+                      , Record
+                            (Dict.fromList
+                                [ ( "a", { name = "a", body = typedInt 42 } )
+                                , ( "b", { name = "b", body = typedString "Hello" } )
+                                ]
+                            )
+                      , "{\"type\":\"record\",\"bind\":{\"a\":{\"type\":\"int\",\"value\":42},\"b\":{\"type\":\"string\",\"value\":\"Hello\"}}}"
+                      )
+                    ]
+                )
+            ]
+        , let
+            runTest : ( String, Declaration Typed.LocatedExpr, String ) -> Test
+            runTest ( description, input, output ) =
+                test description <|
+                    \() ->
+                        input
+                            |> JSON.emitDeclaration
+                            |> Expect.equal output
+          in
+          describe "emitDeclaration"
+            (List.map runTest
+                [ ( "simple"
+                  , { module_ = "Foo"
+                    , name = "bar"
+                    , body = Value <| typedInt 1
+                    }
+                  , """{"type":"decl","name":"Foo$bar","expr":{"type":"int","value":1}}"""
+                  )
+                ]
+            )
+        ]


### PR DESCRIPTION
In order to try out Elm compilation with GraalVM and the Truffle API, I've added an emitter that produces JSON output containing the AST data. There's an "outputFormat" flag in the cli/index.js which can be switched to "JSON" to try it out.

See https://github.com/sgdan/truffle-elm where I've used the JSON output, it does something like this:
JSON AST
-> parse into Kotlin data classes
-> create Truffle nodes from AST data
-> run via GraalVM/Truffle interpreter or generate native linux executable