### PR TITLE
upgrade cli deps

### DIFF
--- a/cli/elm.json
+++ b/cli/elm.json
@@ -9,16 +9,16 @@
         "direct": {
             "Janiczek/transform": "1.1.0",
             "dmy/elm-pratt-parser": "2.0.0",
-            "elm/core": "1.0.2",
-            "elm/json": "1.1.2",
+            "elm/core": "1.0.4",
+            "elm/json": "1.1.3",
             "elm/parser": "1.1.0",
             "elm/project-metadata-utils": "1.0.0",
             "elm-community/basics-extra": "4.0.0",
             "elm-community/dict-extra": "2.4.0",
             "elm-community/graph": "6.0.0",
-            "elm-community/maybe-extra": "5.0.0",
-            "elm-community/result-extra": "2.2.1",
-            "erlandsona/assoc-set": "1.0.0",
+            "elm-community/maybe-extra": "5.1.0",
+            "elm-community/result-extra": "2.3.0",
+            "erlandsona/assoc-set": "1.1.0",
             "pzp1997/assoc-list": "1.0.0",
             "rtfeldman/elm-hex": "1.0.0"
         },
@@ -30,7 +30,7 @@
     "test-dependencies": {
         "direct": {
             "elm-community/random-extra": "3.1.0",
-            "elm-explorations/test": "1.2.1"
+            "elm-explorations/test": "1.2.2"
         },
         "indirect": {
             "elm/html": "1.0.0",


### PR DESCRIPTION
Based on running `elm-json upgrade`.

Without this, elm make fails