### PR TITLE
clarify that a var name may refer to a type

### DIFF
--- a/src/Elm/Data/VarName.elm
+++ b/src/Elm/Data/VarName.elm
@@ -1,9 +1,10 @@
 module Elm.Data.VarName exposing (VarName)
 
-{-| Variable name, eg. the `x` in
+{-| Variable name or a type name, eg. the 'A' and the `x` in
 
+    foo : A
     foo =
-        x + 1
+        bar x
 
 @docs VarName
 


### PR DESCRIPTION
I am confident this is how we use VarName's internally already as
I found this snippet from the Elm.Data.Exposing module:

  type ExposedItem
      = ExposedValue VarName -- exposing (foo)
      | ExposedType VarName -- exposing (Foo)
      | ExposedTypeAndAllConstructors VarName -- exposing (Foo(..))
